### PR TITLE
Trigger to toggled Apply Now Enabled field based on Campaign Active field

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@
 Place to keep code, docs, and other information related to our Salesforce integrations.
 
 All Beyond Z classes and triggers should start with BZ_ for their name.
+
+All System.Debug() logs should be prefixed with the name of the parent
+class or trigger so that we can filter on the current test.  E.g. 
+```
+trigger BZ_CampaignAssigned on CampaignMember (before insert) {
+    System.Debug('BZ_CampaignAssigned: begin trigger');
+    ...
+    String myVar = blah;
+    System.Debug('BZ_CampaignAssigned: some other info we want to log: '
++ myVar);
+    ...
+    
+```

--- a/src/classes/BZ_CampaignActive_TEST.apxc
+++ b/src/classes/BZ_CampaignActive_TEST.apxc
@@ -1,0 +1,33 @@
+@isTest 
+private class BZ_CampaignActive_TEST {
+    static testMethod void validateCampaignActive() {
+        Contact contact1 = new Contact(FirstName='Test', LastName='User1', Best_Email__c='testuser1@bz.org');
+        insert contact1;
+        Contact contact2 = new Contact(FirstName='Test', LastName='User2', Best_Email__c='testuser2@bz.org');
+        insert contact2;
+        
+        Campaign campaign = new Campaign(Name='Test Prospective LCs Campaign Active');
+        insert campaign;
+        
+        CampaignMember cm1 = new CampaignMember();
+        cm1.CampaignId=campaign.Id;
+        cm1.ContactId=contact1.Id;
+        cm1.Apply_Button_Enabled__c=FALSE;
+        insert cm1;
+        
+        CampaignMember cm2 = new CampaignMember();
+        cm2.CampaignId=campaign.Id;
+        cm2.ContactId=contact2.Id;
+        cm2.Apply_Button_Enabled__c=FALSE;
+        insert cm2;
+        
+        // Fires the trigger we're testing.
+        campaign.IsActive = TRUE;
+        update campaign;
+      
+        CampaignMember cm1_updated = [SELECT Id, Apply_Button_Enabled__c FROM CampaignMember WHERE Id = :cm1.Id];
+        System.assertEquals(cm1_updated.Apply_Button_Enabled__c, TRUE);
+        CampaignMember cm2_updated = [SELECT Id, Apply_Button_Enabled__c FROM CampaignMember WHERE Id = :cm2.Id];
+        System.assertEquals(cm2_updated.Apply_Button_Enabled__c,cm2_updated TRUE);
+    }
+}

--- a/src/triggers/BZ_CampaignActive.apxt
+++ b/src/triggers/BZ_CampaignActive.apxt
@@ -1,0 +1,24 @@
+// When a Campaign's Active field is changed, all the members in the campaign get their
+// Apply Now Enabled checkbox updated to match.  This way we can open or close all applications
+// for a Campaign using the Active field.  Note that the Apply Now Enabled checkbox controls
+// whether the Apply Now button is visible on the website.
+trigger BZ_CampaignActive on Campaign (before insert, before update) {
+    //System.Debug('BZ_CampaignActive: begin trigger');
+    for (Campaign campaign : Trigger.new)
+    {
+        if (campaign.Id != null)
+            {
+            System.Debug('BZ_CampaignActive: trigger processing campaign: ' + campaign);
+            List<CampaignMember> cms = [SELECT Id FROM CampaignMember WHERE CampaignId=:campaign.Id];
+            for(CampaignMember cm : cms)
+            {
+                cm.Apply_Button_Enabled__c = campaign.IsActive;
+            }
+            update cms;
+        }
+        else
+        {
+            //System.Debug('BZ_CampaignActive: campaign skipped b/c it\'s being created: ' + campaign);
+        }
+    }
+}


### PR DESCRIPTION
Marking a Campaign as Active (in in-Active), toggles the Apply Now Enabled checkbox or every member in that campaign.