### PR TITLE
Add a trigger when new Leads are created to queue up a Task for the owner

### DIFF
--- a/src/classes/BZ_LeadCreated_TEST.apxc
+++ b/src/classes/BZ_LeadCreated_TEST.apxc
@@ -1,0 +1,15 @@
+@isTest 
+private class BZ_LeadCreated_TEST {
+    static testMethod void validateLeadTask() {
+        User owner = [SELECT Id FROM User Where Id = :System.UserInfo.getUserId()];
+        Lead l = new Lead(OwnerId=owner.Id, LeadSource='Website Signup', FirstName='Someone', LastName='New', Company='Someone New (individual)', Status='Open');
+
+        // This fires the trigger we're testing.
+        insert l;
+        
+        List<Task> resultingTasks = [SELECT Id, WhoId FROM Task
+                                     WHERE WhoId=:l.Id AND
+                                           Subject LIKE '%New Website Signup:%'];
+        System.assert(resultingTasks.size()==1, 'Expected Task to be created to take next steps on Website Signup');
+    }
+}

--- a/src/classes/BZ_TaskFactory.apxc
+++ b/src/classes/BZ_TaskFactory.apxc
@@ -41,6 +41,8 @@ public class BZ_TaskFactory {
             Task t = new Task(
                 OwnerId = owner.Id,           // Assigned To
                 Subject = taskSubjectPrefix + ' To ' + contact.Name,
+                IsReminderSet = true,
+                ReminderDateTime = System.now(),
                 ActivityDate = Date.today(),      // Due Date
                 WhoId = contactId,            // Name
                 WhatId = campaignId,          // Related To
@@ -72,9 +74,33 @@ public class BZ_TaskFactory {
         Task t = new Task(
                 OwnerId = owner.Id,           // Assigned To
                 Subject = System.String.format(taskSubjectPattern, new String[]{contact.Name}),
+                IsReminderSet = true,
+                ReminderDateTime = System.now(),
                 ActivityDate = Date.today(),      // Due Date
                 WhoId = contactId,            // Name
                 WhatId = campaignId);               // Related To
+        return t;
+    }
+    
+    /**
+     * Creates Tasks for the owner of the Lead.
+     * 
+     * taskSubjectPattern is the Subject of the Task where the name of the Lead
+     * is added in the location that you specify.  You specify the location with a single
+     * replacement token used with String.format(String,List<String>) method.  
+     * e.g. createTask(lead, 'The person {0} needs something to happen')
+     */
+    public static Task createTask(Lead lead, String taskSubjectPattern, String description) {
+        // For some reason, the Lead.Name is null in a create trigger: https://developer.salesforce.com/forums/ForumsMain?id=906F00000008yQ5IAI
+        String name = lead.FirstName + ' ' + lead.LastName;
+        Task t = new Task(
+                OwnerId = lead.OwnerId,           // Assigned To
+                Subject = System.String.format(taskSubjectPattern, new String[]{name}),
+                Description = description,
+                IsReminderSet = true,
+                ReminderDateTime = System.now(),
+                ActivityDate = Date.today(),      // Due Date
+                WhoId = lead.Id);                     // Name
         return t;
     }
 }

--- a/src/triggers/BZ_LeadCreated.apxt
+++ b/src/triggers/BZ_LeadCreated.apxt
@@ -1,0 +1,21 @@
+/**
+ * When a new person signs up on the website, a Lead is created
+ * and we want to queue up Tasks for staff to review.
+ */
+trigger BZ_LeadCreated on Lead (after insert) { // Needs to be "after insert" b/c the Lead Id is needed when creating the Task.
+    System.Debug('BZ_LeadCreated: begin trigger');
+    List<Task> tasksToAdd = new List<Task>();
+    for (Lead lead : Trigger.new)
+    {
+        System.debug('BZ_LeadCreated: lead.Id=' + lead.Id);
+        System.debug('BZ_LeadCreated: lead.FirstName=' + lead.FirstName);
+        System.debug('BZ_LeadCreated: lead.OwnerId=' + lead.OwnerId);
+        Task t = BZ_TaskFactory.createTask(lead, 'New Website Signup: {0} -- decide next steps', 'Research and fill out missing Lead fields. Then either convert to a Contact and assign them to appropriate Campaign(s) or mark the Lead Status as Unqualified if this person is someone that we don\'t want to clutter the system.');
+        if (t!=null)
+        {
+            tasksToAdd.add(t);  
+            System.debug('BZ_LeadCreated: Adding new Task: '+ t);
+        }
+    }
+    insert tasksToAdd;
+}


### PR DESCRIPTION
Replaces the workflow so that we can add the Lead's Name in the Task subject