### PR TITLE
Add Email task prefix and new Campaign field

### DIFF
--- a/docs/custom_fields.txt
+++ b/docs/custom_fields.txt
@@ -5,6 +5,7 @@ Lead:
 		Program_Site  # human-readable
 		Request_Availability # checkbox, if set, MeetingTimes must be present
 		Meeting_Times # plain text, multi-line, one item per line
+    Student_Id_In_App
 
 	LEAD
 	Administrative Information

--- a/src/classes/BZ_TaskFactory.apxc
+++ b/src/classes/BZ_TaskFactory.apxc
@@ -40,7 +40,7 @@ public class BZ_TaskFactory {
         {
             Task t = new Task(
                 OwnerId = owner.Id,           // Assigned To
-                Subject = taskSubjectPrefix + ' To ' + contact.Name,
+                Subject = 'Email: ' + taskSubjectPrefix + ' To ' + contact.Name,
                 IsReminderSet = true,
                 ReminderDateTime = System.now(),
                 ActivityDate = Date.today(),      // Due Date


### PR DESCRIPTION
The Email task prefix makes it easier to browse the open Tasks and see which ones would generate an email if Send My Queued Emails were pressed.