### PR TITLE
Don't allow the 'Request Student ID' field for Volunteer campaigns

### DIFF
--- a/docs/validation_rules.txt
+++ b/docs/validation_rules.txt
@@ -7,6 +7,7 @@ CAMPAIGN
 	BZ_RequiredTargetCourse
 	BZ_RequiredType
 	BZ_SourcingInfoOptions
+  BZ_StudentIdNotForVolunteers
 
 CAMPAIGN MEMBER
   BZ_RequireStudentRegistrationCode


### PR DESCRIPTION
It would confure non-students