### PR TITLE
Recruitment flow fixes

### DIFF
--- a/src/classes/BZ_CampaignAssigned_TEST.apxc
+++ b/src/classes/BZ_CampaignAssigned_TEST.apxc
@@ -5,14 +5,15 @@ private class BZ_CampaignAssigned_TEST {
         Lead l = new Lead(OwnerId=UserInfo.getUserId(), User_Type__c='Volunteer', Account_Activated__c=true, LeadSource='Website Signup', FirstName='Someone', LastName='New', Company='Someone New (individual)', Status='Open');
         insert l;
         
+        // THis happens automatically now on lead insertion above.
         // Convert Lead to Contact to get everything setup properly (e.g. Lead.ConvertedContactId must be set).
-        Database.LeadConvert lc = new Database.LeadConvert();
+        /*Database.LeadConvert lc = new Database.LeadConvert();
         lc.setLeadId(l.id);
         LeadStatus convertStatus = [Select Id, MasterLabel FROM LeadStatus WHERE IsConverted=true LIMIT 1];
         lc.setConvertedStatus(convertStatus.MasterLabel);
-        Database.LeadConvertResult lcr = Database.convertLead(lc);        
-        
-        Contact contact = [SELECT Id FROM Contact WHERE Id = :lcr.contactId];
+        Database.LeadConvertResult lcr = Database.convertLead(lc); */    
+        Lead updatedLead = [SELECT Id, ConvertedContactId FROM Lead Where Id = :l.Id];
+        Contact contact = [SELECT Id FROM Contact WHERE Id = :updatedLead.ConvertedContactId];
         Contact campaignOwner = new Contact(FirstName='Test', LastName='CampaignOwner1', OwnerId=userInfo.getUserId());
         insert campaignOwner;
 
@@ -95,5 +96,32 @@ private class BZ_CampaignAssigned_TEST {
                                            WhatId=:updatedCm.CampaignId AND
                                            Subject LIKE '%Send Intro Email%'];
         System.assert(resultingTasks.size()==1, 'Expected Task to be created to Send Intro Email to Other Campaigns');
+    }
+    
+    static testMethod void validateReferrealProgramCampaignAssigned() {
+        Contact campaignOwner = new Contact(FirstName='Test', LastName='CampaignOwner4', OwnerId=userInfo.getUserId());
+        insert campaignOwner;
+        
+        // Mimic someone who we manually entered and assigned to a Referral Program campaign.
+        Contact contact = new Contact(FirstName='Test', LastName='User4');
+        insert contact;
+        
+        // Note: the Campaign.OwnerId refers to the User, so we need to use campaignOwner.OwnerId instead of Id.  See the child relationship of the User object.
+        Campaign campaign = BZ_CampaignFactory_TEST.create(campaignOwner.OwnerId, 'Referral Program');
+        insert campaign;
+        
+        CampaignMember cm = new CampaignMember();
+        cm.CampaignId=campaign.Id;
+        cm.ContactId=contact.Id;
+        
+        // This fires the trigger we're testing.
+        insert cm;
+        
+        CampaignMember updatedCm = [SELECT Id, ContactId, CampaignId FROM CampaignMember WHERE Id=:cm.Id];
+        List<Task> resultingTasks = [SELECT Id, WhoId, WhatId FROM Task
+                                     WHERE WhoId=:updatedCm.ContactId AND
+                                           WhatId=:updatedCm.CampaignId AND
+                                           Subject LIKE '%Send Intro Email%'];
+        System.assert(resultingTasks.size()==0, 'Expected NO Task to be created to Send Intro Email to a Referral Program Campaigns');
     }
 }

--- a/src/classes/BZ_CandidateStatusChanged_TEST.apxc
+++ b/src/classes/BZ_CandidateStatusChanged_TEST.apxc
@@ -127,6 +127,39 @@ private class BZ_CandidateStatusChanged_TEST {
                                            Status='Completed' AND
                                            Subject LIKE '%Review submitted application for%'];
         System.assert(resultingTasks_rejected.size()==1, 'Expected Task to Review the application to be closed when Rejected.');
+        
+        Test.stopTest();
+    }
+    
+    static testMethod void validateReviewAppTaskClosedInterviewRequested() {
+        Contact campaignOwner = new Contact(FirstName='Test', LastName='CampaignOwner_vratc2', OwnerId=userInfo.getUserId());
+        insert campaignOwner;
+        Contact contact_interview = new Contact(FirstName='Test', LastName='AppStatClosedInterview');
+        insert contact_interview;
+        
+        // Note: the Campaign.OwnerId refers to the User, so we need to use campaignOwner.OwnerId instead of Id.  See the child relationship of the User object.
+        Campaign campaign = BZ_CampaignFactory_TEST.create(campaignOwner.OwnerId, 'Program Participants');
+        campaign.App_Interview_Requested_Email_Template__c = 'BZ_SomeInterviewRequestTemplate';
+        insert campaign;
+        
+        CampaignMember cm_interview = new CampaignMember();
+        cm_interview.CampaignId=campaign.Id;
+        cm_interview.ContactId=contact_interview.Id;
+        insert cm_interview;
+        Task t_interview = BZ_TaskFactory.createTask(cm_interview, 'Review submitted application for {0}');
+        insert t_interview;
+        
+        Test.startTest();
+
+        cm_interview.Candidate_Status__c = 'Interview Requested';
+        update cm_interview;
+        
+        List<Task> resultingTasks_interview = [SELECT Id, Status FROM Task 
+                                     WHERE WhoId=:cm_interview.ContactId AND 
+                                           WhatId=:cm_interview.CampaignId AND
+                                           Status='Completed' AND
+                                           Subject LIKE '%Review submitted application for%'];
+        System.assert(resultingTasks_interview.size()==1, 'Expected Task to Review the application to be closed when Interview Requested.');
 
         Test.stopTest();
     }

--- a/src/triggers/BZ_CampaignAssigned.apxt
+++ b/src/triggers/BZ_CampaignAssigned.apxt
@@ -6,6 +6,7 @@ trigger BZ_CampaignAssigned on CampaignMember (before insert) {
     System.Debug('BZ_CampaignAssigned: begin trigger');
     
     List<Task> tasksToAdd = new List<Task>(); 
+    List<Task> tasksToUpdate = new List<Task>(); 
     List<Contact> contactsToUpdate = new List<Contact>();
     
     for (CampaignMember cm : Trigger.new)
@@ -14,43 +15,65 @@ trigger BZ_CampaignAssigned on CampaignMember (before insert) {
         //System.debug('BZ_CampaignAssigned: campaign='+campaign);
         Contact contact = [SELECT Id, Volunteer_Information__c, Participant_Information__c, User_Type__c
                            FROM Contact WHERE Id=:cm.ContactId];
+       
         //System.debug('BZ_CampaignAssigned: contact='+contact);
-        boolean sendWelcomeEMail = false;
+        boolean isApplicableCampaign = false;
         if (campaign.Type == 'Leadership Coaches') {
             // Note: this is also set in a Workflow when the Lead is converted, 
             // but they may signup as one type but then we determine that they are really 
             // a different type so we still want to run this.
             contact.Volunteer_Information__c = 'LC Pipeline';
-            sendWelcomeEMail = true;
+            isApplicableCampaign = true;
         } else if (campaign.Type == 'Program Participants'){
             // Ditto on above comment
             contact.Participant_Information__c = 'Participant Pipeline';
-            sendWelcomeEMail = true;
+            isApplicableCampaign = true;
         } else if (campaign.Type == 'Partners')
         {
             // Website signup as employer partner or university partner
             if ( contact.User_Type__c == 'Employer' || contact.User_Type__c == 'University')
             {
-                sendWelcomeEMail = true;
+                isApplicableCampaign = true;
             }
         }
         else if (campaign.Type == 'Other' && contact.User_Type__c == 'Other')
         {
             // Website signup as "Other"
-            sendWelcomeEMail = true;
+            isApplicableCampaign = true;
         }
         
-        if (sendWelcomeEMail){   
+        if (isApplicableCampaign)
+        {   
             contactsToUpdate.add(contact);
                         
-            Task t = BZ_TaskFactory.createEmailTask(cm, 'Send Intro Email', 'Intro_Email_Template__c');
-            if (t!=null)
+            Task introTask = BZ_TaskFactory.createEmailTask(cm, 'Send Intro Email', 'Intro_Email_Template__c');
+            if (introTask!=null)
             {
-                tasksToAdd.add(t);  
-                System.debug('BZ_CampaignAssigned: Adding new Task: '+ t);
+                tasksToAdd.add(introTask);  
+                System.debug('BZ_CampaignAssigned: Adding new intro Task: '+ introTask);
+            }
+            
+            Id senderId = UserInfo.getUserId();
+            List<Task> tasksToClose = [SELECT Id, WhoId, WhatId, OwnerId, Status, Subject
+                                       FROM Task 
+                                       WHERE WhoId = :contact.Id AND       // Name - this task was created to handle a Lead, but the WhoId seems to be updated to the Contact ID after conversion
+                                           OwnerId = :senderId AND         // Assigned To
+                                           Status != 'Completed' AND
+                                           Subject LIKE '%New Website Signup%'
+                                ];
+            //System.debug('BZ_CampaignAssigned: tasksToClose.size() = ' + tasksToClose.size() );
+
+            // If the task was already closed or deleted, it's a NOOP b/c this is a convenience behavior anyway.
+            if (tasksToClose != null && tasksToClose.size() > 0)
+            {
+                Task taskToClose = tasksToClose.get(0);
+                System.debug('BZ_CampaignAssigned: closing Task = ' + taskToClose );
+                taskToClose.Status = 'Completed';
+                tasksToUpdate.add(taskToClose);
             }
         }
     }
     update contactsToUpdate;
+    update tasksToUpdate;
     insert tasksToAdd;
 }

--- a/src/triggers/BZ_CandidateStatusChanged.apxt
+++ b/src/triggers/BZ_CandidateStatusChanged.apxt
@@ -17,6 +17,8 @@ trigger BZ_CandidateStatusChanged on CampaignMember (before update) {
             //System.debug('BZ_CandidateStatusChanged: cm.Candidate_Status__c=' + cm.Candidate_Status__c);
             if (cm.Candidate_Status__c == 'Interview Requested')
             {
+                closeReviewAppTask = true;
+                
                 Task t = BZ_TaskFactory.createEmailTask(cm, 'Send Interview Request Email', 'App_Interview_Requested_Email_Template__c');
                 if (t!=null)
                 {


### PR DESCRIPTION
When you assign a member to a non-recruitment campaign, don't run the recruitment logic.  Also, close the "review app" task when we request an interview.