### PR TITLE
Fix SendMyQueuedEmails

### DIFF
--- a/src/classes/BZ_BulkEmailer.apxc
+++ b/src/classes/BZ_BulkEmailer.apxc
@@ -19,6 +19,7 @@ public class BZ_BulkEmailer {
                                   AND (               // Email Template To Send
                                         EmailTemplate__c != null OR EmailTemplate__c != ''
                                         )
+                                  LIMIT 10 // Hack for now: The SingleMailMessage can only do 10 per button press.  You'll have to press the button a buunch of times.
                                 ];
 
 //        System.Debug('BZ_BulkEmailer.getQueuedEmails: emailsTasks.size() = '+emailTasks.size());
@@ -36,8 +37,22 @@ public class BZ_BulkEmailer {
     public static Integer sendMyQueuedEmails(List<Task> emailTasksToSend)
     {
         System.debug('BZ_BulkEmailer.sendMyQueuedEmails(emailTasksToSend): begin');
-
+        
         Integer emailsSent = 0;
+        for(Task et : emailTasksToSend)
+        {
+          // send the email template to each Name
+            Contact recipient = [SELECT Id, Email FROM Contact WHERE Id = :et.WhoId];
+            //System.Debug('BZ_BulkEmailer: recipient = ' + recipient);
+            String[] recipients = new String[]{recipient.Email};
+            BZ_SendTemplatedEmail.sendTemplatedEmail(
+                recipients, null, et.EmailTemplate__c, recipient.Id, et.WhatId, null, TRUE, null); 
+            emailsSent++;
+        }
+        
+        /** COMMENTED OUT BC IT DOESN'T MERGE IN CAMPAIGN FIELDS EVEN IF I SET THE WhatId, 
+            BC MassEmailMessage doesn't support it **/
+        /*Integer emailsSent = 0;
         // Segment the list into groups for each email template
         Map<String, List<Id>> emailTemplateToContactIds = new Map<String, List<Id>>();
         for(Task et : emailTasksToSend)
@@ -58,6 +73,7 @@ public class BZ_BulkEmailer {
           //Map <Id, Contact> recipients = new Map<Id, Contact>([SELECT Id, Email FROM Contact WHERE Id IN :emailTemplateToContactIds.get(template)]);
           BZ_SendTemplatedEmail.sendMassTemplatedEmail(emailTemplateToContactIds.get(template), template);
         }
+        */
                      
         // We delete instead of updating to Completed because that causes two 
         // "Activity History" events, which is confusing.  We just want to leave 
@@ -76,6 +92,7 @@ public class BZ_BulkEmailer {
     {
         System.debug('BZ_BulkEmailer.getQueuedApplicationDecisions('+campaign+'): begin');
         Map<String, List<CampaignMember>> emailTemplateToRecipients = new Map<String, List<CampaignMember>>();
+        Integer count = 0;
         
         List<CampaignMember> acceptedUsers = 
             [SELECT CampaignId, ContactId, Contact.Email, Contact.Name FROM CampaignMember 
@@ -87,6 +104,7 @@ public class BZ_BulkEmailer {
         //System.Debug('BZ_BulkEmailer.getQueuedApplicationDecisions: acceptedUsers.get(0).Contact.Email = ' + acceptedUsers.get(0).Contact.Email);
         if (acceptedUsers != null && acceptedUsers.size() > 0)
         {
+            count += acceptedUsers.size();
             emailTemplateToRecipients.put(campaign.App_Accepted_Email_Template__c, acceptedUsers);
         }
         
@@ -100,6 +118,7 @@ public class BZ_BulkEmailer {
         //System.Debug('BZ_BulkEmailer.getQueuedApplicationDecisions: waitlistedUsers.get(0).Contact.Email = ' + waitlistedUsers.get(0).Contact.Email);
         if (waitlistedUsers != null && waitlistedUsers.size() > 0)
         {
+            count += waitlistedUsers.size();
             emailTemplateToRecipients.put(campaign.App_Waitlisted_Email_Template__c, waitlistedUsers);
         }
 
@@ -113,10 +132,39 @@ public class BZ_BulkEmailer {
         //System.Debug('BZ_BulkEmailer.getQueuedApplicationDecisions: rejectedUsers.get(0).Contact.Email = ' + rejectedUsers.get(0).Contact.Email);
         if (rejectedUsers != null && rejectedUsers.size() > 0)
         {
+            count += rejectedUsers.size();
             emailTemplateToRecipients.put(campaign.App_Rejected_Email_Template__c, rejectedUsers);
         }
 
-        return emailTemplateToRecipients;
+        if (count > 10)
+        {
+            // Hack for now b/c SingleMailMessage can only do 10 per button press.
+            // You'll have to press the button a buunch of times.
+            Map<String, List<CampaignMember>> upTo10emailTemplateToRecipients = new Map<String, List<CampaignMember>>();
+            Integer recipientsAdded = 0;
+            for (String emailTemplate : emailTemplateToRecipients.keySet())
+            {
+                upTo10emailTemplateToRecipients.put(emailTemplate, new List<CampaignMember>());
+                List<CampaignMember> cms = emailTemplateToRecipients.get(emailTemplate);
+                for (CampaignMember cm : cms)
+                {
+                    if (recipientsAdded < 10)
+                    {
+                        upTo10emailTemplateToRecipients.get(emailTemplate).add(cm);
+                        recipientsAdded++;
+                    }
+                    else
+                    {
+                        return upTo10emailTemplateToRecipients;
+                    }
+                }
+            }
+            return upTo10emailTemplateToRecipients;
+        }
+        else
+        {
+            return emailTemplateToRecipients;
+        }
     }
     
     /**

--- a/src/classes/BZ_BulkEmailer.apxc
+++ b/src/classes/BZ_BulkEmailer.apxc
@@ -38,16 +38,27 @@ public class BZ_BulkEmailer {
         System.debug('BZ_BulkEmailer.sendMyQueuedEmails(emailTasksToSend): begin');
 
         Integer emailsSent = 0;
+        // Segment the list into groups for each email template
+        Map<String, List<Id>> emailTemplateToContactIds = new Map<String, List<Id>>();
         for(Task et : emailTasksToSend)
         {
-          // send the email template to each Name
-            Contact recipient = [SELECT Id, Email FROM Contact WHERE Id = :et.WhoId];
-            //System.Debug('BZ_BulkEmailer: recipient = ' + recipient);
-            String[] recipients = new String[]{recipient.Email};
-            BZ_SendTemplatedEmail.sendTemplatedEmail(
-                recipients, null, et.EmailTemplate__c, recipient.Id, et.WhatId, null, TRUE, null); 
+            if (emailTemplateToContactIds.containsKey(et.EmailTemplate__c))
+            {
+              emailTemplateToContactIds.get(et.EmailTemplate__c).add(et.WhoId);
+            }
+      else
+            {
+                emailTemplateToContactIds.put(et.EmailTemplate__c, new List<Id>{et.WhoId});
+            }            
             emailsSent++;
         }
+        
+        for (String template : emailTemplateToContactIds.keySet())
+        { 
+          //Map <Id, Contact> recipients = new Map<Id, Contact>([SELECT Id, Email FROM Contact WHERE Id IN :emailTemplateToContactIds.get(template)]);
+          BZ_SendTemplatedEmail.sendMassTemplatedEmail(emailTemplateToContactIds.get(template), template);
+        }
+                     
         // We delete instead of updating to Completed because that causes two 
         // "Activity History" events, which is confusing.  We just want to leave 
         // the history of the actual email sent, not that fact that it needed to be sent.

--- a/src/classes/BZ_BulkEmailer_TEST.apxc
+++ b/src/classes/BZ_BulkEmailer_TEST.apxc
@@ -147,4 +147,115 @@ private class BZ_BulkEmailer_TEST {
         CampaignMember rejectedCmResult = [SELECT Application_Decision_Sent__c FROM CampaignMember WHERE Id = :rejectedCm.Id];
         System.assertEquals(TRUE, rejectedCmResult.Application_Decision_Sent__c);
     }
+    
+    static testMethod void validateMoreThanTenSendQueuedApplicationDecisions() {
+        System.Debug('BZ_BulkEmailer_TEST.validateMoreThanTenSendQueuedApplicationDecisions(): begin');
+        
+        Integer emailsSent = 0;
+        Campaign campaign = null;
+        Contact waitlistedRecipient = null;
+        Contact acceptedRecipient = null;
+        Contact rejectedRecipient = null;
+        
+        CampaignMember waitlistedCm = null;
+        CampaignMember acceptedCm = null;
+        CampaignMember rejectedCm = null;
+
+        List<CampaignMember> testCms = null;
+        
+        // We do the runAs() b/c of a bug in salesforce where the template is not actually created.  
+        // This, in conjunction with the startTest and stopTest below which forces the async future method 
+        // to run synchronously: 
+        // https://developer.salesforce.com/forums/ForumsMain?id=906F00000008wSQIAY
+        User sender = [SELECT Id FROM User Where Id = :System.UserInfo.getUserId()];    
+        System.runAs(sender) 
+        {
+            List<Contact> testContacts = new List<Contact>();
+            waitlistedRecipient = new Contact(FirstName='TestWaitlistedEmail', LastName='Recipient', Email='TestWaitlistedEmail.Recipient@bz.org');
+            testContacts.add(waitlistedRecipient);
+            Contact waitlistedRecipient2 = new Contact(FirstName='TestWaitlistedEmail2', LastName='Recipient', Email='TestWaitlistedEmail.Recipient2@bz.org');
+            testContacts.add(waitlistedRecipient2);
+            Contact waitlistedRecipient3 = new Contact(FirstName='TestWaitlistedEmail3', LastName='Recipient', Email='TestWaitlistedEmail.Recipient3@bz.org');
+            testContacts.add(waitlistedRecipient3);
+            acceptedRecipient = new Contact(FirstName='TestAcceptedEmail', LastName='Recipient', Email='TestAcceptedEmail.Recipient@bz.org');
+            testContacts.add(acceptedRecipient);
+            Contact acceptedRecipient2 = new Contact(FirstName='TestAcceptedEmail2', LastName='Recipient', Email='TestAcceptedEmail.Recipient2@bz.org');
+            testContacts.add(acceptedRecipient2);
+            Contact acceptedRecipient3 = new Contact(FirstName='TestAcceptedEmail3', LastName='Recipient', Email='TestAcceptedEmail.Recipient3@bz.org');
+            testContacts.add(acceptedRecipient3);        
+            Contact acceptedRecipient4 = new Contact(FirstName='TestAcceptedEmail4', LastName='Recipient', Email='TestAcceptedEmail.Recipient4@bz.org');
+            testContacts.add(acceptedRecipient4);
+            rejectedRecipient = new Contact(FirstName='TestRejectedEmail', LastName='Recipient', Email='TestRejectedEmail.Recipient@bz.org');
+            testContacts.add(rejectedRecipient);
+            Contact rejectedRecipient2 = new Contact(FirstName='TestRejectedEmail2', LastName='Recipient', Email='TestRejectedEmail.Recipient2@bz.org');
+            testContacts.add(rejectedRecipient2);
+            Contact rejectedRecipient3 = new Contact(FirstName='TestRejectedEmail3', LastName='Recipient', Email='TestRejectedEmail.Recipient3@bz.org');
+            testContacts.add(rejectedRecipient3);
+            Contact rejectedRecipient4 = new Contact(FirstName='TestRejectedEmail4', LastName='Recipient', Email='TestRejectedEmail.Recipient4@bz.org');
+            testContacts.add(rejectedRecipient4);
+            
+            insert testContacts;
+            
+            String waitlistedEmailDeveloperName='TestWaitlistedEmailTemplateToSend';
+            String acceptedEmailDeveloperName='TestAcceptedEmailTemplateToSend';
+            String rejectedEmailDeveloperName='TestRejectedEmailTemplateToSend';
+            
+            campaign = BZ_CampaignFactory_TEST.create();
+            campaign.Name='Test Send Queued App Decisions Campaign1'; 
+            campaign.App_Waitlisted_Email_Template__c=waitlistedEmailDeveloperName;
+            campaign.App_Accepted_Email_Template__c=acceptedEmailDeveloperName;
+            campaign.App_Rejected_Email_Template__c=rejectedEmailDeveloperName;
+            insert campaign; 
+            
+            testCms = new List<CampaignMember>();
+            waitlistedCm = new CampaignMember(CampaignId=campaign.Id, ContactId=waitlistedRecipient.Id, Candidate_Status__c='Waitlisted');
+            testCms.add(waitlistedCm);
+            CampaignMember waitlistedCm2 = new CampaignMember(CampaignId=campaign.Id, ContactId=waitlistedRecipient2.Id, Candidate_Status__c='Waitlisted');
+            testCms.add(waitlistedCm2);
+            CampaignMember waitlistedCm3 = new CampaignMember(CampaignId=campaign.Id, ContactId=waitlistedRecipient3.Id, Candidate_Status__c='Waitlisted');
+            testCms.add(waitlistedCm3);
+            
+            acceptedCm = new CampaignMember(CampaignId=campaign.Id, ContactId=acceptedRecipient.Id, Candidate_Status__c='Accepted');
+            testCms.add(acceptedCm);
+            CampaignMember acceptedCm2 = new CampaignMember(CampaignId=campaign.Id, ContactId=acceptedRecipient2.Id, Candidate_Status__c='Accepted');
+            testCms.add(acceptedCm2);
+            CampaignMember acceptedCm3 = new CampaignMember(CampaignId=campaign.Id, ContactId=acceptedRecipient3.Id, Candidate_Status__c='Accepted');
+            testCms.add(acceptedCm3);
+            CampaignMember acceptedCm4 = new CampaignMember(CampaignId=campaign.Id, ContactId=acceptedRecipient4.Id, Candidate_Status__c='Accepted');
+            testCms.add(acceptedCm4);
+            
+            rejectedCm = new CampaignMember(CampaignId=campaign.Id, ContactId=rejectedRecipient.Id, Candidate_Status__c='Rejected');
+            testCms.add(rejectedCm);
+            CampaignMember rejectedCm2 = new CampaignMember(CampaignId=campaign.Id, ContactId=rejectedRecipient2.Id, Candidate_Status__c='Rejected');
+            testCms.add(rejectedCm2);
+            CampaignMember rejectedCm3 = new CampaignMember(CampaignId=campaign.Id, ContactId=rejectedRecipient3.Id, Candidate_Status__c='Rejected');
+            testCms.add(rejectedCm3);
+            CampaignMember rejectedCm4 = new CampaignMember(CampaignId=campaign.Id, ContactId=rejectedRecipient4.Id, Candidate_Status__c='Rejected');
+            testCms.add(rejectedCm4);
+            
+            insert testCms;
+        
+            Test.startTest();
+            // Note, this Util method is to avoid a MIXED_DML_OPERATION error described here: 
+            // http://www.tgerm.com/2012/04/mixeddmloperation-dml-operation-on.html        
+            BZ_SendTemplatedEmail.insertEmailTemplate('Test Waitlisted Email Template', waitlistedEmailDeveloperName, 'text', sender.Id);
+            BZ_SendTemplatedEmail.insertEmailTemplate('Test Accepted Email Template', acceptedEmailDeveloperName, 'text', sender.Id);
+            BZ_SendTemplatedEmail.insertEmailTemplate('Test Rejected Email Template', rejectedEmailDeveloperName, 'text', sender.Id);
+
+            Test.stopTest();
+            
+            // Run the test
+            System.Debug('BZ_BulkEmailer_TEST: BZ_BulkEmailer.sendQueuedApplicationDecisions(BZ_BulkEmailer.getQueuedApplicationDecisions(campaign='+campaign+'))');        
+            emailsSent = BZ_BulkEmailer.sendQueuedApplicationDecisions(BZ_BulkEmailer.getQueuedApplicationDecisions(campaign));
+        }
+
+        System.assert(testCms.size() > 10, 'Test should have more than 10 Campaign Members');
+        System.assertEquals(10, emailsSent, 'Expected 10 emails to be sent, not '+emailsSent);
+        CampaignMember waitlistedCmResult = [SELECT Application_Decision_Sent__c FROM CampaignMember WHERE Id = :waitlistedCm.Id];
+        System.assertEquals(TRUE, waitlistedCmResult.Application_Decision_Sent__c);
+        CampaignMember acceptedCmResult = [SELECT Application_Decision_Sent__c FROM CampaignMember WHERE Id = :acceptedCm.Id];
+        System.assertEquals(TRUE, acceptedCmResult.Application_Decision_Sent__c);
+        CampaignMember rejectedCmResult = [SELECT Application_Decision_Sent__c FROM CampaignMember WHERE Id = :rejectedCm.Id];
+        System.assertEquals(TRUE, rejectedCmResult.Application_Decision_Sent__c);
+    }
 }

--- a/src/classes/BZ_SendTemplatedEmail.apxc
+++ b/src/classes/BZ_SendTemplatedEmail.apxc
@@ -1,15 +1,25 @@
 public class BZ_SendTemplatedEmail {
 
-    // Sends an email using an Email Template.
-  // 
-  // 
-  //  templateId   must be ID of an Email template
-  //  targetObjId must be a Contact, User, Lead Id -- also used in merge fields of template recipient.xxxx
-  //  whatId    must be an SObject that is used in the merge fields of the template relatedTo.xxxx
-  //  fromId    if non null, use current user, otherwise, use this ID (most likely an org wide no reply id)
-  //  bcc      not permitted when using templates
-  //  
-  //  Adapted from: https://developer.salesforce.com/forums/ForumsMain?id=906F000000094ClIAI
+    /**
+     * Sends an email using an Email Template.
+   * 
+   * 
+   *  templateId   must be ID of an Email template
+   *  targetObjId must be a Contact, User, Lead Id -- also used in merge fields of template recipient.xxxx
+   *  whatId    must be an SObject that is used in the merge fields of the template relatedTo.xxxx
+   *  fromId    if non null, use current user, otherwise, use this ID (most likely an org wide no reply id)
+   *  bcc      not permitted when using templates
+   *  
+   * IMPORTANT: this method can only be called 10 times in a single Apex context (aka run).
+   * Use SendMassTemplatedEmail() below if you want to send more than 10.
+   * 
+   * EXAMPLE USAGE:
+   * Contact recipient = [SELECT Id, Email FROM Contact WHERE Id = :someId];
+     * String[] recipients = new String[]{recipient.Email};
+     * BZ_SendTemplatedEmail.sendTemplatedEmail(recipients, null, et.EmailTemplate__c, recipient.Id, null, null, TRUE, null);
+   * 
+   * Adapted from: https://developer.salesforce.com/forums/ForumsMain?id=906F000000094ClIAI
+   */
   public static void sendTemplatedEmail(String[] toRecipients, String[] ccRecipients, String templateDeveloperName, ID targetObjId, Id whatId, ID orgWideEmailId, Boolean saveAsActivity, Attachment[] attachList ) {
         Messaging.SingleEmailMessage email = new Messaging.SingleEmailMessage();
     
@@ -22,7 +32,7 @@ public class BZ_SendTemplatedEmail {
                                'Unable to locate EmailTemplate using name: ' + templateDeveloperName + 
                            ' refer to Setup | Communications Templates | ' + templateDeveloperName);
         }
-    
+        
         email.setToAddresses(toRecipients);
         email.setCcAddresses(ccRecipients);
         email.setTargetObjectId(targetObjId);
@@ -40,5 +50,49 @@ public class BZ_SendTemplatedEmail {
         catch (EmailException e) {
             throw new BZ_EmailException('BZ_SendTemplatedEmail.sendTemplatedEmail(): error -- ' + e.getMessage());
         }
+    }
+    
+    /**
+     * Sends a mass email using an Email Template.
+   * 
+   *  contactIds   the list of Id's for the Contacts you want to email
+   *  templateDeveloperName the API developer name of the Email Template
+   * 
+   *  Adapted from: http://salesforce.stackexchange.com/questions/30874/how-to-write-a-mass-email-in-apex-code-i-have-tried-if-any-know-what-error-in-th
+   */
+    public static void sendMassTemplatedEmail(List<Id> contactIds, String templateDeveloperName) {    
+        Id templateId;  
+        try {
+            templateId = [select id, name from EmailTemplate where DeveloperName = : templateDeveloperName].id;
+        }
+        catch (Exception e) {
+          throw new BZ_EmailException ('BZ_SendTemplatedEmail.sendMassTemplatedEmail(): '+
+                               'Unable to locate EmailTemplate using name: ' + templateDeveloperName + 
+                           ' refer to Setup | Communications Templates | ' + templateDeveloperName);
+        }
+        
+        Messaging.MassEmailMessage emails = new Messaging.MassEmailMessage();
+        emails.setTargetObjectIds(contactIds);
+        emails.setTemplateId(templateId);
+    
+        System.debug(LoggingLevel.INFO,'BZ_SendTemplatedEmail.sendMassTemplatedEmail(contactIds:' + contactIds + ' templateDeveloperName:' + templateDeveloperName + ') -- begin');
+        try {
+            Messaging.sendEmail(new Messaging.MassEmailMessage[] {emails});
+            return;
+        }
+        catch (EmailException e) {
+            throw new BZ_EmailException('BZ_SendTemplatedEmail.sendMassTemplatedEmail(): error -- ' + e.getMessage());
+        }
+    }
+    
+    // If you get a MIXED_DML_OPERATION, use this utility method to do it in 
+    // future transaction.  
+    // See: http://www.salesforce.com/us/developer/docs/apexcode/Content/apex_dml_non_mix_sobjects.htm
+    // Note: you can't pass SObjects as parameters into async methods (aka future methods)
+    @future
+    public static void insertEmailTemplate(String name, String developerName, String templateType, Id folderId)
+    {
+        EmailTemplate et = new EmailTemplate(Name=name, DeveloperName=developerName, TemplateType=templateType, FolderId=folderId, IsActive=TRUE);
+        insert et;
     }
 }

--- a/src/classes/BZ_SendTemplatedEmail.apxc
+++ b/src/classes/BZ_SendTemplatedEmail.apxc
@@ -58,6 +58,8 @@ public class BZ_SendTemplatedEmail {
    *  contactIds   the list of Id's for the Contacts you want to email
    *  templateDeveloperName the API developer name of the Email Template
    * 
+   *  Note: this won't merge in the Campaign field in a template
+   * 
    *  Adapted from: http://salesforce.stackexchange.com/questions/30874/how-to-write-a-mass-email-in-apex-code-i-have-tried-if-any-know-what-error-in-th
    */
     public static void sendMassTemplatedEmail(List<Id> contactIds, String templateDeveloperName) {    

--- a/src/visualforcepages/BZ_SendMyQueuedEmails.vfp
+++ b/src/visualforcepages/BZ_SendMyQueuedEmails.vfp
@@ -1,19 +1,20 @@
 <!-- Page that handles the "Send My Queued Emails" button. -->
 <apex:page standardController="Campaign" extensions="BZ_SendMyQueuedEmails">
-  <apex:form>
+  <apex:form >
     <apex:pageBlock id="buttons" rendered="{!hasRun==false}">
         <apex:pageMessages id="messages"/>
         <apex:pageMessage severity="confirm" title="Are you sure?" summary="You are about to send the following queued emails to the following members of this campaign. If you're sure you want to do this hit Send" />
-        <apex:pageBlockSection>
-            <apex:pageBlockSectionItem>
+        <apex:pageMessage severity="info" summary="NOTE: this will only do the first 10 emails.  If you have 10 in this list, keep pressing the button again until there are none left." />
+        <apex:pageBlockSection >
+            <apex:pageBlockSectionItem >
                 <apex:outputText id="previewEmailsToSend" value="{!emailsToSendDisplayList}" escape="false">
                 </apex:outputText>
             </apex:pageBlockSectionItem>
         </apex:pageBlockSection>
-        <apex:pageBlockSection><br/></apex:pageBlockSection>
-        <apex:pageBlockSection>
-            <apex:pageBlockSectionItem>
-                <apex:outputPanel>
+        <apex:pageBlockSection ><br/></apex:pageBlockSection>
+        <apex:pageBlockSection >
+            <apex:pageBlockSectionItem >
+                <apex:outputPanel >
                 <table>
                 <tr>
                     <td><apex:commandButton action="{!run}" value="Send" /></td>
@@ -31,4 +32,3 @@
     </apex:outputPanel>
     </apex:form>    
 </apex:page>
-

--- a/src/visualforcepages/BZ_SendQueuedApplicationDecisions.vfp
+++ b/src/visualforcepages/BZ_SendQueuedApplicationDecisions.vfp
@@ -4,6 +4,7 @@
     <apex:pageBlock id="buttons" rendered="{!hasRun==false}">
         <apex:pageMessages id="messages"/>
         <apex:pageMessage severity="confirm" title="Are you sure?" summary="You are about to send FINAL application decision emails to the following members of this campaign. If you're sure you want to do this hit Send" />
+        <apex:pageMessage severity="info" summary="NOTE: this will only do the first 10 emails.  If you have 10 in this list, keep pressing the button again until there are none left." />
         <apex:pageBlockSection >
             <apex:pageBlockSectionItem >
                 <apex:outputText id="previewEmailsToSend" value="{!applicationDecisionsToSendDisplayList}" escape="false">


### PR DESCRIPTION
Going back to using SingleEmailMessage b/c we need to set the WhatId in order for Campaign merge fields to work.  MassEmailMessage doesn't support that.  Put in place a hack to limit the emails sent to 10 so that you can hit the button repeatedly to clear out the queue.  I plan to put in place a better fix to batch it up on the backend at some point.