### PR TITLE
Change Close Recruitment logic to only keep certain Opted Out Reasons

### DIFF
--- a/src/classes/BZ_CloseRecruitmentController.apxc
+++ b/src/classes/BZ_CloseRecruitmentController.apxc
@@ -79,10 +79,19 @@ public class BZ_CloseRecruitmentController {
             m_campaign.Status = 'In Progress';
             update m_campaign;
             
-            List<CampaignMember> membersToPurge = [SELECT Id, ContactId, CampaignId, Candidate_Status__c FROM CampaignMember 
+            List<CampaignMember> membersToPurge = [SELECT Id, ContactId, CampaignId, Candidate_Status__c, Opted_Out_Reason__c FROM CampaignMember 
                                                    WHERE CampaignId = :m_campaign.Id AND
                                                    Candidate_Status__c <> 'Waitlisted' AND
-                                                   Candidate_Status__c <> 'Opted Out'];
+                                                   (
+                                                       Candidate_Status__c <> 'Opted Out' OR
+                                                       (Candidate_Status__c = 'Opted Out' AND 
+                                                           (
+                                                               Opted_Out_Reason__c <> 'No Time' AND
+                                                               Opted_Out_Reason__c <> 'No Available Units' AND
+                                                               Opted_Out_Reason__c <> 'No Interest Right Now'
+                                                           )
+                                                        )
+                                                   )];
             System.Debug('BZ_CloseRecruitmentController.run(): membersToPurge = ' + membersToPurge);
             
             Set<Id> confirmedMemberIds = new Set<Id>();

--- a/src/classes/BZ_CloseRecruitmentController_TEST.apxc
+++ b/src/classes/BZ_CloseRecruitmentController_TEST.apxc
@@ -1,12 +1,18 @@
 @isTest 
 private class BZ_CloseRecruitmentController_TEST {
     static testMethod void validateRun() {
+        List<Contact> contactsToInsert = new List<Contact>();
         Contact campaignOwner = new Contact(FirstName='Test', LastName='CampaignOwner', OwnerId=userInfo.getUserId());
-        insert campaignOwner;
+        contactsToInsert.add(campaignOwner);
         Contact contactWaitlist = new Contact(FirstName='Test', LastName='UserWaitlisted', Volunteer_Information__c='LC Pipeline');
-        insert contactWaitlist;
+        contactsToInsert.add(contactWaitlist);
+        Contact contactOptedOutDropped = new Contact(FirstName='Test', LastName='UserOptedOutDropped', Volunteer_Information__c='LC Pipeline');
+        contactsToInsert.add(contactOptedOutDropped);
+        Contact contactOptedOutNoTime = new Contact(FirstName='Test', LastName='UserOptedOutNoTime', Volunteer_Information__c='LC Pipeline');
+        contactsToInsert.add(contactOptedOutNoTime);
         Contact contactConfirmed = new Contact(FirstName='Test', LastName='UserConfirmed', Volunteer_Information__c='Current LC');
-        insert contactConfirmed;
+        contactsToInsert.add(contactConfirmed);
+        insert contactsToInsert;
         
         // Note: the Campaign.OwnerId refers to the User, so we need to use campaignOwner.OwnerId instead of Id.  See the child relationship of the User object.
         Campaign campaign = BZ_CampaignFactory_TEST.create(campaignOwner.OwnerId, 'Leadership Coaches');
@@ -14,24 +20,50 @@ private class BZ_CloseRecruitmentController_TEST {
         campaign.Previous_Candidate_New_Invite__c = reinviteEmailTemplateName;
         insert campaign;
         
+        List<CampaignMember> campaignMembersToInsert = new List<CampaignMember>();
         CampaignMember cmWaitlist = new CampaignMember();
         cmWaitlist.CampaignId=campaign.Id;
         cmWaitlist.ContactId=contactWaitlist.Id;
         cmWaitlist.Candidate_Status__c = 'Waitlisted';
         cmWaitlist.Application_Status__c = 'Submitted';
-        insert cmWaitlist;
+        campaignMembersToInsert.add(cmWaitlist);
+        
+        CampaignMember cmOptedOutDropped = new CampaignMember();
+        cmOptedOutDropped.CampaignId=campaign.Id;
+        cmOptedOutDropped.ContactId=contactOptedOutDropped.Id;
+        cmOptedOutDropped.Candidate_Status__c = 'Opted Out';
+        cmOptedOutDropped.Opted_Out_Reason__c = 'Dropped';
+        cmOptedOutDropped.Application_Status__c = 'Submitted';
+        campaignMembersToInsert.add(cmOptedOutDropped);
+        
+        CampaignMember cmOptedOutNoTime = new CampaignMember();
+        cmOptedOutNoTime.CampaignId=campaign.Id;
+        cmOptedOutNoTime.ContactId=contactOptedOutNoTime.Id;
+        cmOptedOutNoTime.Candidate_Status__c = 'Opted Out';
+        cmOptedOutNoTime.Opted_Out_Reason__c = 'No Time';
+        cmOptedOutNoTime.Application_Status__c = 'Submitted';
+        campaignMembersToInsert.add(cmOptedOutNoTime);
         
         CampaignMember cmConfirmed = new CampaignMember();
         cmConfirmed.CampaignId=campaign.Id;
         cmConfirmed.ContactId=contactConfirmed.Id;
         cmConfirmed.Candidate_Status__c = 'Confirmed';
         cmConfirmed.Application_Status__c = 'Submitted';
-        insert cmConfirmed;
+        campaignMembersToInsert.add(cmConfirmed);
         
+        insert campaignMembersToInsert;
+        
+        List<Task> tasksToInsert = new List<Task>();
         Task tWaitlist = new Task(Subject='Test CampaignWaitlist', CampaignMemberId__c=cmWaitlist.Id, WhoId=contactWaitlist.Id, WhatId=campaign.Id);
-        insert tWaitlist;
+        tasksToInsert.add(tWaitlist);
+        Task tOptedOutDropped = new Task(Subject='Test CampaignOptedOutDropped', CampaignMemberId__c=cmOptedOutDropped.Id, WhoId=contactOptedOutDropped.Id, WhatId=campaign.Id);
+        tasksToInsert.add(tOptedOutDropped);
+        Task tOptedOutNoTime = new Task(Subject='Test CampaignOptedOutNoTime', CampaignMemberId__c=cmOptedOutNoTime.Id, WhoId=contactOptedOutNoTime.Id, WhatId=campaign.Id);
+        tasksToInsert.add(tOptedOutNoTime);
         Task tConfirm = new Task(Subject='Test CampaignConfirm', CampaignMemberId__c=cmConfirmed.Id, WhoId=contactConfirmed.Id, WhatId=campaign.Id);
-        insert tConfirm;
+        tasksToInsert.add(tConfirm);
+        
+        insert tasksToInsert;
         
       ApexPages.StandardController sc = new ApexPages.standardController(campaign);
             
@@ -43,36 +75,66 @@ private class BZ_CloseRecruitmentController_TEST {
         String newAvailableMeetingTimes = 'Wednesday:5';
         controller.newCampaignName = newCampaignName;
         controller.newAvailableMeetingTimes = newAvailableMeetingTimes;
+        Test.startTest();
         PageReference result = controller.run();
+        Test.stopTest();
         
         System.Assert(result != null, 'controller.run() returned null');
         System.assert(controller.newCampaignName == newCampaignName, 'The BZ_CloseRecruitmentController should have newCampaignName = '+newCampaignName +' . Not newCampaignName ='+controller.newCampaignName);
         System.assert(controller.newAvailableMeetingTimes == newAvailableMeetingTimes, 'The BZ_CloseRecruitmentController should have newAvailableMeetingTimes = '+newAvailableMeetingTimes +' . Not newAvailableMeetingTimes ='+controller.newAvailableMeetingTimes);
         System.Assert(controller.getEmailTemplates() != null, 'controller.getEmailTemplates() is null');
         List<CampaignMember> campaignMembersNotPurged = [SELECT Id, Name, Status, CampaignId, ContactId, Candidate_Status__c FROM CampaignMember WHERE CampaignId = :campaign.Id];
-        System.Assert(campaignMembersNotPurged.size() == 1, 'Expected 1 CampaignMember to not be purged. Found '+campaignMembersNotPurged.size());
-        System.Assert(campaignMembersNotPurged.get(0).Id == cmWaitlist.Id, 'cmWaitlist not found in campaign');
+        System.Assert(campaignMembersNotPurged.size() == 2, 'Expected 2 CampaignMember to not be purged. Found '+campaignMembersNotPurged.size());
+        for (CampaignMember cm : campaignMembersNotPurged)
+        {
+            if (cm.Id != cmWaitlist.Id && cm.Id != cmOptedOutNoTime.Id)
+            {
+                System.assert(false, 'Found Campaign Member that should not have been kept in active campaign: cm = ' + cm);
+            }
+        }
         List<Task> tasksNotPurged = [SELECT Id, WhoId, EmailTemplate__c FROM Task WHERE WhatId = :campaign.Id];
         Boolean foundWaitlistTask = false;
-        Boolean foundReinviteTask = false;
+        Boolean foundNoTimeTask = false;
+        Boolean foundWaitlistReinviteTask = false;
+        Boolean foundNoTimeReinviteTask = false;
         for (Task t : tasksNotPurged)
         {
-            System.Assert(t.WhoId == contactWaitlist.Id, 'Only tasks for contactWaitlist should be left on campaign.  Found task = '+t);
+            if (t.WhoId != contactWaitlist.Id && t.WhoId != contactOptedOutNoTime.Id)
+            {
+                System.Assert(false, 'Only tasks for contactWaitlist and contactOptedOutNoTime should be left on campaign.  Found task = '+t);    
+            }
+            
             if (t.Id == tWaitlist.Id) {
                 foundWaitlistTask = true;
             }
-            if (t.EmailTemplate__c != null && t.EmailTemplate__c == reinviteEmailTemplateName){
-                foundReinviteTask = true;
+            
+            if (t.WhoId == contactWaitlist.Id && t.EmailTemplate__c != null && t.EmailTemplate__c == reinviteEmailTemplateName){
+                foundWaitlistReinviteTask = true;
+            }
+            if (t.Id == tOptedOutNoTime.Id) {
+                foundNoTimeTask = true;
+            }
+            
+            if (t.WhoId == contactOptedOutNoTime.Id && t.EmailTemplate__c != null && t.EmailTemplate__c == reinviteEmailTemplateName){
+                foundNoTimeReinviteTask = true;
             }
         }
         System.Assert(foundWaitlistTask, 'tWaitlist not found in campaign');
-        System.Assert(foundReinviteTask, 'Task to reinvite member to apply not found in campaign');
+        System.Assert(foundNoTimeTask, 'tOptedOutNoTime not found in campaign');
+        System.Assert(foundWaitlistReinviteTask, 'Task to reinvite Waitlisted member to apply not found in campaign');
+        System.Assert(foundNoTimeReinviteTask, 'Task to reinvite Opted Out No Time member to apply not found in campaign');
         
         Contact updatedConfirmedContact = [SELECT Id, Volunteer_Information__c FROM Contact WHERE Id = :contactConfirmed.Id];
         System.Assert(updatedConfirmedContact.Volunteer_Information__c == 'Former LC', 'When Close Recruitment runs, Confirmed members should become alumni');
         
         Contact updatedWaitlistedContact = [SELECT Id, Volunteer_Information__c FROM Contact WHERE Id = :contactWaitlist.Id];
         System.Assert(updatedWaitlistedContact.Volunteer_Information__c == 'LC Pipeline', 'When Close Recruitment runs, non-Confirmed members should still be in the pipeline.');
+        
+        Contact updatedDroppedContact = [SELECT Id, Volunteer_Information__c FROM Contact WHERE Id = :contactOptedOutDropped.Id];
+        System.Assert(updatedDroppedContact.Volunteer_Information__c == 'LC Pipeline', 'When Close Recruitment runs, non-Confirmed members should still be in the pipeline.');
+
+        Contact updatedNoTimeContact = [SELECT Id, Volunteer_Information__c FROM Contact WHERE Id = :contactOptedOutNoTime.Id];
+        System.Assert(updatedNoTimeContact.Volunteer_Information__c == 'LC Pipeline', 'When Close Recruitment runs, non-Confirmed members should still be in the pipeline.');
         
         ////////////
         // TODO: validate that a snapshot campaign was taken

--- a/src/classes/BZ_TaskClosed_TEST.apxc
+++ b/src/classes/BZ_TaskClosed_TEST.apxc
@@ -20,6 +20,6 @@ private class BZ_TaskClosed_TEST {
         update t1;
 
         updatedContact = [SELECT Id, Name, Have_Met__c FROM Contact WHERE Id = :contact.Id];
-        System.assert(updatedContact.Have_Met__c == true, 'Have Met? should have been set to true.')
+        System.assert(updatedContact.Have_Met__c == true, 'Have Met? should have been set to true.');
     }
 }

--- a/src/visualforcepages/BZ_CloseRecruitment.vfp
+++ b/src/visualforcepages/BZ_CloseRecruitment.vfp
@@ -24,7 +24,7 @@
                         'Waitlisted' - means that we wanted to accept them, but there were no more spots.<br/>
                     </apex:outputLabel>
                     <apex:outputLabel style="padding-left:5em">
-                        'Opted Out' - means that during the interview they indicated that they couldn’t commit to the program at that time.<br/>
+                        'Opted Out' - with an 'Opted Out Reason' of 'No Time', 'No Available Units', or 'No Interest Right Now' means that during the interview they indicated that they couldn’t commit to the program at that time but may be interested in the future.<br/>
                     </apex:outputLabel>
                     <apex:outputLabel >
                         <br/>


### PR DESCRIPTION
Many indicate that we should not try to recruit them anymore.  E.g. "No Interest Ever".  When we talk to them and figure out why they can't do the program, setting the Opted Out Reason lets us know we've already reached out as well as controls if we will reach back out in the future.