### PR TITLE
Fix parent campaign logic in Close Recruitment

### DIFF
--- a/src/classes/BZ_CloseRecruitmentController.apxc
+++ b/src/classes/BZ_CloseRecruitmentController.apxc
@@ -3,7 +3,8 @@ public class BZ_CloseRecruitmentController {
     private static final String NEW_CAMPAIGN_NAME_PROMPT = '<Please enter new Campaign Name>';
     private final List<SelectOption> m_emailTemplateOptions;
     private ApexPages.StandardController m_controller {get; set;}
-    private Campaign m_campaign {get;set;} // Active campaign
+    public Campaign m_campaign {get;set;} // Active campaign
+    public Campaign m_campaignSnapshot {get;set;} // Cloned Snapshot campaign
     private Date m_oldStartDate {get; set;}
     private Date m_oldEndDate {get; set;}
     
@@ -59,13 +60,12 @@ public class BZ_CloseRecruitmentController {
             System.Debug('BZ_CloseRecruitmentController.run(): about to clone m_campaign = ' + m_campaign);
             BZ_ClonePlusController cloneController = new BZ_ClonePlusController(m_campaign.Id, new Set<String>{'CampaignMember', 'Task'});
             System.Debug('BZ_CloseRecruitmentController.run(): getParentClone()');
-            Campaign clonedCampaign = (Campaign)cloneController.getParentClone(); 
-            clonedCampaign.IsActive = false;
-            clonedCampaign.Status = 'Completed'; // This allows the Campaign Assigned trigger to update the alumni status
-            clonedCampaign.ParentId = m_campaign.Id;
-            System.Debug('BZ_CloseRecruitmentController.run(): insert clonedCampaign = '+clonedCampaign);
-            insert clonedCampaign; // Need to do this before inserting children so that it gets an ID
-            System.Debug('BZ_CloseRecruitmentController.run(): done inserting clonedCampaign = '+clonedCampaign);
+            m_campaignSnapshot = (Campaign)cloneController.getParentClone(); 
+            m_campaignSnapshot.IsActive = false;
+            m_campaignSnapshot.Status = 'Completed'; // This allows the Campaign Assigned trigger to update the alumni status
+            System.Debug('BZ_CloseRecruitmentController.run(): insert m_campaignSnapshot = '+m_campaignSnapshot);
+            insert m_campaignSnapshot; // Need to do this before inserting children so that it gets an ID
+            System.Debug('BZ_CloseRecruitmentController.run(): done inserting m_campaignSnapshot = '+m_campaignSnapshot);
             
             System.Debug('BZ_CloseRecruitmentController.run(): getChildrenClones()');
             List<sObject> childrenClones = cloneController.getChildrenClones();
@@ -77,6 +77,7 @@ public class BZ_CloseRecruitmentController {
             m_campaign.Meeting_Times__c = newAvailableMeetingTimes;
             m_campaign.Previous_Candidate_New_Invite__c = prevCandidateEmailTemplate;
             m_campaign.Status = 'In Progress';
+            m_campaign.ParentId = m_campaignSnapshot.Id;
             update m_campaign;
             
             List<CampaignMember> membersToPurge = [SELECT Id, ContactId, CampaignId, Candidate_Status__c, Opted_Out_Reason__c FROM CampaignMember 
@@ -104,7 +105,7 @@ public class BZ_CloseRecruitmentController {
                     }
                 }
                 
-                BZ_Notifications.changeCampaigns(memberContactIdsToPurge, clonedCampaign.Id, false);
+                BZ_Notifications.changeCampaigns(memberContactIdsToPurge, m_campaignSnapshot.Id, false);
                 System.Debug('BZ_CloseRecruitmentController.run(): deleting membersToPurge = ' + membersToPurge);
                 delete membersToPurge;
             }

--- a/src/classes/BZ_CloseRecruitmentController_TEST.apxc
+++ b/src/classes/BZ_CloseRecruitmentController_TEST.apxc
@@ -82,6 +82,7 @@ private class BZ_CloseRecruitmentController_TEST {
         System.Assert(result != null, 'controller.run() returned null');
         System.assert(controller.newCampaignName == newCampaignName, 'The BZ_CloseRecruitmentController should have newCampaignName = '+newCampaignName +' . Not newCampaignName ='+controller.newCampaignName);
         System.assert(controller.newAvailableMeetingTimes == newAvailableMeetingTimes, 'The BZ_CloseRecruitmentController should have newAvailableMeetingTimes = '+newAvailableMeetingTimes +' . Not newAvailableMeetingTimes ='+controller.newAvailableMeetingTimes);
+        System.assert(controller.m_campaign.ParentId == controller.m_campaignSnapshot.Id, 'The Campaign Snapshot should be set to the parent of the Active campaign.  controller.m_campaign.ParentId = '+controller.m_campaign.ParentId +' . Not controller.m_campaignSnapshot.Id ='+controller.m_campaignSnapshot.Id);
         System.Assert(controller.getEmailTemplates() != null, 'controller.getEmailTemplates() is null');
         List<CampaignMember> campaignMembersNotPurged = [SELECT Id, Name, Status, CampaignId, ContactId, Candidate_Status__c FROM CampaignMember WHERE CampaignId = :campaign.Id];
         System.Assert(campaignMembersNotPurged.size() == 2, 'Expected 2 CampaignMember to not be purged. Found '+campaignMembersNotPurged.size());


### PR DESCRIPTION
Old code had most recent campaigns be the parent of older campaigns.  It's actually the other way around.  The most recent campaign was created from the older campaigns and should have the older snapshot be the parent.  This way, you start at most recent and keep clicking the parent to get to the original oldest campaign