### PR TITLE
Move Bulk Invite logic to background thread and queue up REINVITE email

### DIFF
--- a/src/classes/BZ_BulkInviteController.apxc
+++ b/src/classes/BZ_BulkInviteController.apxc
@@ -3,6 +3,12 @@
  * Queues up an INVITE email and a text message invite (if there is a phone number set).
  */
 public class BZ_BulkInviteController extends BZ_CsvBulkInviteUploader {
+    // This is true when the Bulk Invite add Campaign Member logic is running
+    public static Boolean IsBulkInviteRunning {get; set;}
+    static {
+        IsBulkInviteRunning = false;
+    }
+    
     private ApexPages.StandardController m_controller {get; set;}
     private Campaign m_campaign {get;set;}
     List<Contact> m_contactsToBulkInvite;
@@ -11,6 +17,8 @@ public class BZ_BulkInviteController extends BZ_CsvBulkInviteUploader {
     private String m_contactsToInviteDisplay;
     private boolean m_contactsLoaded;
     private boolean m_textMessagesSent;
+    private ID m_jobId;
+    private BZ_BulkInviteControllerQueueable m_queueableController;
 
     public BZ_BulkInviteController(ApexPages.StandardController controller) {
         System.debug('BZ_BulkInviteController(): begin');
@@ -18,12 +26,15 @@ public class BZ_BulkInviteController extends BZ_CsvBulkInviteUploader {
             controller.addFields(new String[]{'Id', 'OwnerId', 'Type', 'Program_Site__c'}); // Avoid error: "SObject row was retrieved via SOQL without querying the requested field".  These fields are used when creating a Task history of the text messages sent.
         }
         this.m_controller = controller;
+        this.m_campaign = (Campaign)m_controller.getRecord();
         this.m_contactsToBulkInvite = new List<Contact>();
         this.m_textMessageBody = '{!Contact.FirstName}, ready to apply to Braven? Go to: https://bebraven.org/apply-now or reply STOP to stop receiving text messages.';
         this.m_contactsLoaded = false;
         this.m_textMessagesSent = false;
         this.m_resultMessage = '';
-        this.m_campaign = (Campaign)m_controller.getRecord();
+        hasCompleted = false;
+        hasStarted = false;
+        progressString = '. . .';
     }
 
     // method called from the VF's action attribute to run the logic
@@ -33,13 +44,14 @@ public class BZ_BulkInviteController extends BZ_CsvBulkInviteUploader {
         {
             // We need to reload the contacts from the database so that composite
             // fields like Name are populated and we have all the fields needed by
-            // the BZ_BulkTexter.
-            Set<Id> contactIdsToText = new Set<Id>();
+            // the BZ_BulkTexter.  Also, we can't load them by Id b/c the Id is populated
+            // during async execution and doesn't seem to propogate back here.
+            Set<String> contactEmailsToText = new Set<String>();
             System.debug('BZ_BulkInviteController.sendTextMessages(): m_contactsToBulkInvite = '+m_contactsToBulkInvite);
             for (Contact c : m_contactsToBulkInvite){
-                contactIdsToText.add(c.Id);
+                contactEmailsToText.add(c.Email);
             }
-            List<Contact> contactsToText = [SELECT Id, FirstName, LastName, Name, Phone FROM Contact WHERE Id in :contactIdsToText];
+            List<Contact> contactsToText = [SELECT Id, FirstName, LastName, Name, Phone FROM Contact WHERE Email in :contactEmailsToText];
             System.debug('BZ_BulkInviteController.sendTextMessages(): about to send text messages to: '+contactsToText);
             BZ_BulkTexter texter = new BZ_BulkTexter(contactsToText, m_textMessageBody, m_campaign);
             texter.sendTextMessages();
@@ -90,7 +102,7 @@ public class BZ_BulkInviteController extends BZ_CsvBulkInviteUploader {
                 FROM Contact 
                 WHERE Email in :contactsToAdd.keySet()];
 
-           if (existingContacts.size() > 0)
+            if (existingContacts.size() > 0)
             {
                 for (Contact c : existingContacts)
                 {
@@ -102,77 +114,28 @@ public class BZ_BulkInviteController extends BZ_CsvBulkInviteUploader {
                     contactsToAdd.remove(c.Email.toLowerCase());
                 }
             }
-
-            Savepoint sp = Database.setSavepoint();
-            try
+            
+            m_contactsToBulkInvite = new List<Contact>();
+            m_contactsToBulkInvite.addAll(contactsToAdd.values());
+            m_contactsToBulkInvite.addAll(existingContacts);
+            System.debug('BZ_BulkInviteController.finishRead(): m_contactsToBulkInvite = '+m_contactsToBulkInvite);
+            
+            m_contactsToInviteDisplay = '<table border="1"><tr><td style="padding:0 15px 0 15px;"><strong>Name</strong></td><td style="padding:0 15px 0 15px;"><strong>Email</strong></td><td style="padding:0 15px 0 15px;"><strong>Phone</strong></td></tr>';
+            for (Contact c : m_contactsToBulkInvite)
             {
-                System.debug('BZ_BulkInviteController.finishRead(): inserting the following new contacts: ' + contactsToAdd.values());
-                insert contactsToAdd.values();
-                
-                // We may need to add their phone number or correct their name, 
-                // so we stil update the contacts using the info in the sheet.
-                System.debug('BZ_BulkInviteController.finishRead(): updating the following existing contacts: ' + existingContacts);
-                update existingContacts;
-                
-                m_contactsToBulkInvite = new List<Contact>();
-                m_contactsToBulkInvite.addAll(contactsToAdd.values());
-                m_contactsToBulkInvite.addAll(existingContacts);
-                System.debug('BZ_BulkInviteController.finishRead(): m_contactsToBulkInvite = '+m_contactsToBulkInvite);
-
-                List<CampaignMember> cms = new List<CampaignMember>();
-                m_contactsToInviteDisplay = '<table border="1"><tr><td style="padding:0 15px 0 15px;"><strong>Name</strong></td><td style="padding:0 15px 0 15px;"><strong>Email</strong></td><td style="padding:0 15px 0 15px;"><strong>Phone</strong></td></tr>';
-                for (Contact c : m_contactsToBulkInvite)
-                {
-                    CampaignMember cm;
-                    if (m_campaign.Type == 'Program Participants'){
-                        cm = new CampaignMember(ContactId=c.Id, campaignId=m_campaign.Id, Undergrad_University__c=m_campaign.Program_Site__c);
-                    } else {
-                        cm = new CampaignMember(ContactId=c.Id, campaignId=m_campaign.Id);
-                    }
-                    cms.add(cm);
-                    m_contactsToInviteDisplay += '<tr><td style="padding:0 15px 0 15px;">' + c.FirstName + ' ' + c.LastName + '</td><td style="padding:0 15px 0 15px;">' + c.Email + '</td><td style="padding:0 15px 0 15px;">' + c.Phone + '</td></tr>';    
-                    System.debug('BZ_BulkInviteController.finishRead(): Added the following CampaignMember: '+cm);
-                }
-                m_contactsToInviteDisplay += '</table>';
-                insert cms;
-
-                Map<String, String[]> interactionInfoMap = getInteractionInfoMap();
-                Map<Id, Contact> contactsToCreateInteractionInfoFor = new Map<Id, Contact>();
-                for (Contact c : m_contactsToBulkInvite){
-                    contactsToCreateInteractionInfoFor.put(c.Id, c);
-                }
-                List<Task> interactionTasksToAdd = BZ_TaskFactory.createTasks(cms, 'Interaction: How We Met {0}');
-                for (Task t : interactionTasksToAdd){
-                    Contact c = contactsToCreateInteractionInfoFor.get(t.WhoId);
-                    String[] interactionInfo = interactionInfoMap.get(c.Email.toLowerCase());
-                    if (interactionInfo != null){
-                        t.Interaction_Type__c = interactionInfo[0];
-                        t.Description = interactionInfo[1];
-                        c.Initial_Connection__c = interactionInfo[1];
-                    }
-                    else {
-                        throw new BZ_BulkInviteException('No Interaction Info found for "'+c.Email+'".  Please make sure to set the Interaction Info for everyone -- Bulk Invite failed!');
-                    }
-                    t.Status = 'Completed';
-                    t.IsReminderSet = false;
-                    if (m_campaign.Type == 'Program Participants'){
-                        c.Undergrad_University__c = m_campaign.Program_Site__c;
-                    }
-                    c.npsp__Primary_Affiliation__c = primaryAffiliationId;
-                }
-                insert interactionTasksToAdd;
-                update contactsToCreateInteractionInfoFor.values();
-
-                m_contactsLoaded = true;
-            } 
-            catch (Exception e)
-            {
-                // roll everything back in case of error
-                Database.rollback(sp);
-                ApexPages.addMessages(e);
-                System.Debug('BZ_BulkInviteController.finishRead(): Exception = ' + e);
-                m_resultMessage = 'Failed adding the specified users.  Details: ' + e;
+                m_contactsToInviteDisplay += '<tr><td style="padding:0 15px 0 15px;">' + c.FirstName + ' ' + c.LastName + '</td><td style="padding:0 15px 0 15px;">' + c.Email + '</td><td style="padding:0 15px 0 15px;">' + c.Phone + '</td></tr>';
             }
+            m_contactsToInviteDisplay += '</table>';
+            m_contactsLoaded = true;
+            
+            Map<String, String[]> interactionInfoMap = getInteractionInfoMap();
+            
+            m_queueableController = new BZ_BulkInviteControllerQueueable(
+                m_campaign, primaryAffiliationId, contactsToAdd, existingContacts,
+                m_contactsToBulkInvite, interactionInfoMap);
+            
+            m_jobId = System.enqueueJob(m_queueableController);
+            hasStarted = true;
         }
         else
         {
@@ -180,6 +143,26 @@ public class BZ_BulkInviteController extends BZ_CsvBulkInviteUploader {
             m_resultMessage = 'There are no Contacts to invite.  Double check the spreadsheet?';
         }
         System.debug('BZ_BulkInviteController: finishRead() end');
+    }
+    
+     public PageReference checkComplete(){
+        AsyncApexJob job = [SELECT Status, NumberOfErrors, ExtendedStatus FROM AsyncApexJob WHERE Id=:m_jobId];
+        System.debug('BZ_BulkInviteController.checkComplete(): job status = '+job);         
+        if (job.Status == 'Completed'){
+            hasCompleted = true;
+            progressString = 'Success!';
+        } else if (job.Status == 'Failed'){
+            progressString = 'Uh oh, something went wrong!  Here is the error: <br/><br/>' + job.ExtendedStatus;
+            hasCompleted = true;
+            ApexPages.Message errormsg = new ApexPages.Message(ApexPages.severity.ERROR,'The Bulk Invite operation failed.  Please contact your system administrator.');
+            ApexPages.addMessage(errormsg);
+            m_resultMessage = 'Failed adding the specified users.  Details: ' + job.ExtendedStatus;
+        }
+        else {
+            progressString += ' .';
+            hasCompleted = false;
+        }
+        return null;
     }
 
     public String getTextMessageBody(){
@@ -206,6 +189,111 @@ public class BZ_BulkInviteController extends BZ_CsvBulkInviteUploader {
     public String getContactsToInviteDisplay(){
         return m_contactsToInviteDisplay;
     }
+                                        
+    /*
+     * Starts off false and set to true when the operation is complete.
+     */    
+    public Boolean hasCompleted { get; set; }
+    
+    /*
+     * Starts off false and set to true when the operation is queued up.
+     */    
+    public Boolean hasStarted { get; set; }
+    
+    /*
+     * Displays progress as we poll the status of the job.
+     */
+    public String progressString { get; set; }
     
     public class BZ_BulkInviteException extends Exception {}
+    
+    private class BZ_BulkInviteControllerQueueable implements Queueable, Database.AllowsCallouts {
+    
+        private Campaign m_campaign;
+        private Id m_primaryAffiliationId;
+        Map<String, Contact> m_contactsToAdd;
+        List<Contact> m_existingContactsToUpdate;
+        List<Contact> m_contactsToBulkInvite;
+        Map<String, String[]> m_interactionInfoMap;
+        
+        public BZ_BulkInviteControllerQueueable(Campaign campaign, Id primaryAffiliationId, 
+                                                Map<String, Contact> contactsToAdd,
+                                                List<Contact> existingContactsToUpdate,
+                                                List<Contact> contactsToBulkInvite,
+                                                Map<String, String[]> interactionInfoMap)
+        {
+            m_campaign = campaign;
+            m_primaryAffiliationId = primaryAffiliationId;
+            m_contactsToAdd = contactsToAdd;
+            m_existingContactsToUpdate = existingContactsToUpdate;
+            m_contactsToBulkInvite = contactsToBulkInvite;
+            m_interactionInfoMap = interactionInfoMap;
+        }
+        
+        public void execute(QueueableContext context)
+        {
+            System.Debug('BZ_BulkInviteControllerQueueable.execute(): begin');
+            Savepoint sp = Database.setSavepoint();
+            IsBulkInviteRunning = true;
+            try 
+            {
+                System.debug('BZ_BulkInviteControllerQueueable.finishRead(): inserting the following new contacts: ' + m_contactsToAdd.values());
+                insert m_contactsToAdd.values();
+                
+                // We may need to add their phone number or correct their name, 
+                // so we stil update the contacts using the info in the sheet.
+                System.debug('BZ_BulkInviteControllerQueueable.execute(): updating the following existing contacts: ' + m_existingContactsToUpdate);
+                update m_existingContactsToUpdate;
+                
+                List<CampaignMember> cms = new List<CampaignMember>();
+                for (Contact c : m_contactsToBulkInvite)
+                {
+                    CampaignMember cm;
+                    if (m_campaign.Type == 'Program Participants'){
+                        cm = new CampaignMember(ContactId=c.Id, campaignId=m_campaign.Id, Undergrad_University__c=m_campaign.Program_Site__c);
+                    } else {
+                        cm = new CampaignMember(ContactId=c.Id, campaignId=m_campaign.Id);
+                    }
+                    cms.add(cm);
+                    System.debug('BZ_BulkInviteControllerQueueable.execute(): Added the following CampaignMember: '+cm);
+                }
+                insert cms;
+
+                Map<Id, Contact> contactsToCreateInteractionInfoFor = new Map<Id, Contact>();
+                for (Contact c : m_contactsToBulkInvite){
+                    contactsToCreateInteractionInfoFor.put(c.Id, c);
+                }
+                List<Task> interactionTasksToAdd = BZ_TaskFactory.createTasks(cms, 'Interaction: How We Met {0}');
+                for (Task t : interactionTasksToAdd){
+                    Contact c = contactsToCreateInteractionInfoFor.get(t.WhoId);
+                    String[] interactionInfo = m_interactionInfoMap.get(c.Email.toLowerCase());
+                    if (interactionInfo != null){
+                        t.Interaction_Type__c = interactionInfo[0];
+                        t.Description = interactionInfo[1];
+                        c.Initial_Connection__c = interactionInfo[1];
+                    }
+                    else {
+                        throw new BZ_BulkInviteException('No Interaction Info found for "'+c.Email+'".  Please make sure to set the Interaction Info for everyone -- Bulk Invite failed!');
+                    }
+                    t.Status = 'Completed';
+                    t.IsReminderSet = false;
+                    if (m_campaign.Type == 'Program Participants'){
+                        c.Undergrad_University__c = m_campaign.Program_Site__c;
+                    }
+                    c.npsp__Primary_Affiliation__c = m_primaryAffiliationId;
+                }
+                insert interactionTasksToAdd;
+                update contactsToCreateInteractionInfoFor.values();
+            } catch (Exception e){
+                // roll everything back in case of error
+                Database.rollback(sp);
+                System.Debug('BZ_BulkInviteControllerQueueable.execute(): Exception = ' + e);
+                throw e;
+            }
+            finally {
+                IsBulkInviteRunning = false;
+            }
+            System.Debug('BZ_BulkInviteControllerQueueable.execute(): end');
+        }
+    }
 }

--- a/src/classes/BZ_BulkInviteController_TEST.apxc
+++ b/src/classes/BZ_BulkInviteController_TEST.apxc
@@ -75,14 +75,15 @@ private class BZ_BulkInviteController_TEST {
         
         Test.startTest();
         PageReference result = controller.ProcessFile(csvContents);
+        Test.stopTest(); // Force the queued background worker process to complete
         String textMessageBody = controller.getTextMessageBody();
         controller.setTextMessageBody(textMessageBody + 'SLIGHTLY CHANGED!');
         if (controller.getContactsLoaded() && !String.isEmpty(controller.getContactsToInviteDisplay()))
         {
             controller.sendTextMessages();
         }
-        Test.stopTest();
         
+        System.assertEquals(false, BZ_BulkInviteController.IsBulkInviteRunning);
         System.assert(controller.getTextMessagesSent(), 'Text messages not sent!');
         List<Contact> duplicateExsitingContacts = [SELECT Id FROM Contact WHERE Email = :existingEmail1];
         System.assert(duplicateExsitingContacts.size() == 1, 'Expected 1 contact with email: ' + existingEmail1 + '.  Found: ' + duplicateExsitingContacts.size());
@@ -174,11 +175,17 @@ private class BZ_BulkInviteController_TEST {
             'Brian,xTest4,badEmail,badPhone,,,,\n'+
             'badRow\n';
 
+        Boolean exceptionCaught = false;
         Test.startTest();
-        PageReference result = controller.ProcessFile(csvContents);
-        Test.stopTest();
+        try {
+            PageReference result = controller.ProcessFile(csvContents);
+            Test.stopTest();
+        } catch(Exception e){
+            exceptionCaught = true;
+        }
 
-        System.assert(!String.isEmpty(controller.getResultMessage()), 'Result Message should be set');
+        System.assertEquals(false, BZ_BulkInviteController.IsBulkInviteRunning);
+        System.AssertEquals(true, exceptionCaught);
         System.assert(controller.getTextMessagesSent() == false, 'Text messages should not be sent!');
 
         List<CampaignMember> campaignMembers = [SELECT Id, Name, FirstName, LastName, Email, Phone, ContactId FROM CampaignMember WHERE CampaignId = :campaign.Id];
@@ -209,11 +216,17 @@ private class BZ_BulkInviteController_TEST {
             'Brian,xTest1,email1@email.com,5554443333,Phone Call,Description of phone call\n'+
             'Brian,xTest5,email2@email.com,5554443333,,\n';
 
+        Boolean exceptionCaught = false;
         Test.startTest();
-        PageReference result = controller.ProcessFile(csvContents);            
-        Test.stopTest();
+        try {
+            PageReference result = controller.ProcessFile(csvContents);
+            Test.stopTest();            
+        } catch(BZ_BulkInviteController.BZ_BulkInviteException e){
+            exceptionCaught = true;
+        }
 
-        System.assert(!String.isEmpty(controller.getResultMessage()), 'Result Message should be set');
+        System.assertEquals(false, BZ_BulkInviteController.IsBulkInviteRunning);
+        System.AssertEquals(true, exceptionCaught);
 
         List<CampaignMember> campaignMembers = [SELECT Id, Name, FirstName, LastName, Email, Phone, ContactId FROM CampaignMember WHERE CampaignId = :campaign.Id];
         System.Assert(campaignMembers.size() == 0, 'Expected 0 CampaignMembers. Found '+campaignMembers.size());
@@ -245,6 +258,7 @@ private class BZ_BulkInviteController_TEST {
                 'Brian,xTest1,email@email.com,5554443333,Phone Call,Description of phone call\n'+
                 'Brian,xTest2,email2@email.com,5554443334,Phone Call,Description of phone call\n';
             PageReference result = controller.ProcessFile(csvContents);
+            Test.stopTest(); // This forces the background queued process to complete
             if (controller.getContactsLoaded() && !String.isEmpty(controller.getContactsToInviteDisplay()))
             {
                 controller.sendTextMessages();
@@ -252,8 +266,8 @@ private class BZ_BulkInviteController_TEST {
         } finally {
             BZ_BulkTexter.SimilateExceptionWhileSendingTexts = false;
         }
-        Test.stopTest();
 
+        System.assertEquals(false, BZ_BulkInviteController.IsBulkInviteRunning);
         System.assert(!String.isEmpty(controller.getResultMessage()), 'Result Message should be set');
         System.assert(controller.getResultMessage().contains('Failed sending text messages to the following phone numbers'),'The result message of trying to send texts isnt what was expected.  Actual: '+controller.getResultMessage());
     }
@@ -284,6 +298,7 @@ private class BZ_BulkInviteController_TEST {
         PageReference result = controller.ProcessFile(csvContents);
         Test.stopTest();
 
+        System.assertEquals(false, BZ_BulkInviteController.IsBulkInviteRunning);
         System.assert(!String.isEmpty(controller.getResultMessage()), 'Result Message should be set');
         System.assert(controller.getTextMessagesSent() == false, 'Text messages should not be sent!');
 

--- a/src/classes/BZ_BulkTexter.apxc
+++ b/src/classes/BZ_BulkTexter.apxc
@@ -11,12 +11,14 @@ public class BZ_BulkTexter {
     /**
      * Constructor that takes a list of contacts, a text message to send to them,
      * and the Campaign to record that the text activity will be recorded
-     * on in bulk.  Note: this supports the merge field {!Contact.FirstName} in the
-     * textMessageBody.  If present, it will be replaced by each Contact's actual first name.
+     * on in bulk.  Note: this supports the merge field {!Contact.FirstName} and
+     * {!Contact.Mass_Text_Merge_Field__c} in the textMessageBody.
      */
     public BZ_BulkTexter(List<Contact> contacts, String textMessageBody, Campaign campaign)
     {
         System.debug('BZ_BulkTexter('+contacts+', '+textMessageBody+', '+ campaign +'): enter');
+        // The max callouts in a transaction is 100.  We have to move this to batches to send more.
+        if (contacts.size() > 100) throw new TextMessageSendException('Mass texting only supports up to 100 recipients.  You specified ' + contacts.size());
         m_contacts = contacts;
         m_textMessageBody = textMessageBody;
         m_campaign = campaign;

--- a/src/classes/BZ_CampaignAssigned_TEST.apxc
+++ b/src/classes/BZ_CampaignAssigned_TEST.apxc
@@ -156,23 +156,42 @@ private class BZ_CampaignAssigned_TEST {
         // Mimic someone who we manually entered and added to a Participant Campaign. e.g. no signup date or BZ User Id
         Contact contact = new Contact(FirstName='Test', LastName='User5', User_Type__c='Undergrad');
         insert contact;
+        // Mimic someone who had already signed up on the website.
+        Contact existingContact = new Contact(FirstName='Test2', LastName='User6', User_Type__c='Undergrad', BZ_User_Id__c=1234, Signup_Date__c=DateTime.now());
+        insert existingContact;
         
         // Note: the Campaign.OwnerId refers to the User, so we need to use campaignOwner.OwnerId instead of Id.  See the child relationship of the User object.
         Campaign campaign = BZ_CampaignFactory_TEST.create(campaignOwner.OwnerId, 'Program Participants');
         insert campaign;
         
+        List<CampaignMember> cms = new List<CampaignMember>();
         CampaignMember cm = new CampaignMember();
         cm.CampaignId=campaign.Id;
         cm.ContactId=contact.Id;
+        cms.add(cm);
+        
+        CampaignMember cmExisting = new CampaignMember();
+        cmExisting.CampaignId=campaign.Id;
+        cmExisting.ContactId=existingContact.Id;
+        cms.add(cmExisting);
         
         // This fires the trigger we're testing.
-        insert cm;
+        insert cms;
         
+        // Brand new prospects get the Invite email directing them to the signup form
         CampaignMember updatedCm = [SELECT Id, ContactId, CampaignId FROM CampaignMember WHERE Id=:cm.Id];
         List<Task> resultingTasks = [SELECT Id, WhoId, WhatId FROM Task
                                      WHERE WhoId=:updatedCm.ContactId AND
                                            WhatId=:updatedCm.CampaignId AND
                                            Subject LIKE '%Send Invite Email%'];
         System.assert(resultingTasks.size()==1, 'Expected Task to be created to Send Invite Email to a Program Participants that didnt signup');
+        
+        // People who have accounts are sent the Intro email telling them to log back in.
+        CampaignMember updatedExistingCm = [SELECT Id, ContactId, CampaignId FROM CampaignMember WHERE Id=:cmExisting.Id];
+        List<Task> resultingTasks2 = [SELECT Id, WhoId, WhatId FROM Task
+                                     WHERE WhoId=:updatedExistingCm.ContactId AND
+                                           WhatId=:updatedExistingCm.CampaignId AND
+                                           Subject LIKE '%Send Intro Email%'];
+        System.assert(resultingTasks2.size()==1, 'Expected Task to be created to Send Intro Email to a Program Participants that had already signed up');
     }
 }

--- a/src/classes/BZ_CloseRecruitmentController.apxc
+++ b/src/classes/BZ_CloseRecruitmentController.apxc
@@ -284,8 +284,8 @@ public class BZ_CloseRecruitmentController {
                     }
                     
                     List<Task> tasksToAdd = 
-                        BZ_TaskFactory.createEmailTasks(membersNotPurged, 
-                                                        'Reinvite For New Program', 
+                        BZ_TaskFactory.createEmailTasks(membersNotPurged,
+                                                        'Send ReInvite Email', 
                                                         'Previous_Candidate_New_Invite__c');
                     System.Debug('BZ_CloseRecruitmentControllerQueueable.execute(): inserting tasksToAdd = ' + tasksToAdd);
                     insert tasksToAdd;

--- a/src/triggers/BZ_CampaignAssigned.apxt
+++ b/src/triggers/BZ_CampaignAssigned.apxt
@@ -132,8 +132,13 @@ trigger BZ_CampaignAssigned on CampaignMember (before insert) {
             {
                 if (hasSignedUpOnWebsite)
                 {
-                  campaignMembersToCreateIntroTasksFor.add(cm);
-                    System.Debug('BZ_CampaignAssigned: queuing up Intro email for '+cm);
+                    if (BZ_BulkInviteController.IsBulkInviteRunning){
+                        campaignMembersToCreateReinviteTasksFor.add(cm);
+                        System.Debug('BZ_CampaignAssigned: queuing up Reinvite email for '+cm+' because they already have an account and are being Bulk Invited to a new Campaign.');
+                    } else {
+                      campaignMembersToCreateIntroTasksFor.add(cm);
+                        System.Debug('BZ_CampaignAssigned: queuing up Intro email for '+cm);
+                    }
                 }
                 else
                 {
@@ -146,20 +151,20 @@ trigger BZ_CampaignAssigned on CampaignMember (before insert) {
 
     if (campaignMembersToCreateInviteTasksFor.size() > 0)
     {
-        tasksToAdd = BZ_TaskFactory.createEmailTasks(campaignMembersToCreateInviteTasksFor, 
-                                                 'Send Invite Email', 'Invite_Email_Template__c');
+        tasksToAdd.addAll(BZ_TaskFactory.createEmailTasks(campaignMembersToCreateInviteTasksFor, 
+                                                 'Send Invite Email', 'Invite_Email_Template__c'));
     }
     
     if (campaignMembersToCreateIntroTasksFor.size() > 0)
     {
-        tasksToAdd = BZ_TaskFactory.createEmailTasks(campaignMembersToCreateIntroTasksFor, 
-                                                 'Send Intro Email', 'Intro_Email_Template__c');
+        tasksToAdd.addAll(BZ_TaskFactory.createEmailTasks(campaignMembersToCreateIntroTasksFor, 
+                                                 'Send Intro Email', 'Intro_Email_Template__c'));
     }
     
     if (campaignMembersToCreateReinviteTasksFor.size() > 0)
     {
-        tasksToAdd = BZ_TaskFactory.createEmailTasks(campaignMembersToCreateReinviteTasksFor, 
-                                                 'Reinvite For New Program', 'Previous_Candidate_New_Invite__c');
+        tasksToAdd.addAll(BZ_TaskFactory.createEmailTasks(campaignMembersToCreateReinviteTasksFor, 
+                                                 'Send ReInvite Email', 'Previous_Candidate_New_Invite__c'));
     }
     
     Id senderId = UserInfo.getUserId();

--- a/src/visualforcepages/BZ_BulkInvite.vfp
+++ b/src/visualforcepages/BZ_BulkInvite.vfp
@@ -2,11 +2,22 @@
 <apex:page standardController="Campaign" extensions="BZ_BulkInviteController">
   <apex:form >
     <apex:pageMessages id="messages"/>
-    <apex:pageBlock id="uploadSection" rendered="{!contactsLoaded==false}">
-        <apex:pageMessage severity="confirm" title="Upload a .csv file of user information to add to this campaign" summary="The users uploaded will be added to this campaign as Prospects and have an INVITE email and text message queued up." />
+    <apex:pageBlock id="uploadSection" rendered="{!hasStarted==false}">
+        <apex:pageMessage severity="confirm" 
+                          title="Upload a .csv file of user information to add to this campaign"
+                          summary="The users uploaded will be added to this campaign as Prospects and have an INVITE email or REINVITE email queued up depending on if they've signed up in the past and have an account or not.  On the next screen, you'll have the option to send them a text message." />
+        Note: the reason that users with existing accounts who have signed up in the past
+        get a REINVITE email instead of an INVITE email is because the instructions should just 
+        have them log back into their account instead of asking them to signup again.
+        If they try to signup, it will say their email is already registered 
+        or they will lose previous application information they already filled out if they 
+        signup with a new email. <font color="blue">Make sure the templates are set accordingly!</font>
+        <br/> <br/>
         <!--  Component to allow user to upload file from local machine -->
+        <div style="border:2px solid red; padding:15px">
         <apex:inputFile value="{!contentFile}" filename="{!nameFile}" />
         <apex:commandButton action="{!ReadFile}" value="Invite Them!" id="uploadButton" style="width:150px;"/>
+        </div>
         <br/> <br/>
         <font color="red"> <b>Note: </b></font> the .csv should have 6 columns with the info below.
         Please use <a href="https://drive.google.com/a/beyondz.org/file/d/0BxkyYmQz77njdHdpRk9IeXRlLVk/view?usp=sharing" target="_blank"> this template </a>.
@@ -42,9 +53,14 @@
             <li>For Fellows, the Undergraduate University is set to the Program Site on the Campaign.  You can change this after if you'd like.</li>
         </ul>
     </apex:pageBlock>
+      <apex:pageBlock id="processStatus" rendered="{!hasStarted && textMessagesSent==false}">
+          <apex:outputText value="Bulk Invite is running.  It may take a minute or two.  The status will be shown when it finishes.<br/><br/>" escape="false" rendered="{!hasStarted&&hasCompleted==false}"/>
+          <apex:outputText value="{!progressString}" id="progress" escape="false"/>
+          <apex:actionPoller enabled="{!hasStarted&&hasCompleted==false}" action="{!checkComplete}" interval="5" reRender="processStatus,progress,sendTextMessageSection"/>
+      </apex:pageBlock>
     <apex:outputPanel id="sendTextMessageSection" style="display:block;width:100%;"> <!-- Needed to rerender child on button press.  Cant do it directly. -->
-    <apex:pageBlock rendered="{!contactsLoaded==true && textMessagesSent==false}">
-        <strong>The following contacts have been added to the Campaign and have an INVITE email queued up.</strong>
+    <apex:pageBlock rendered="{!contactsLoaded==true && hasCompleted==true && textMessagesSent==false}">
+        <strong>The following contacts have been added to the Campaign and have an INVITE or INTRO email queued up depending on if they already have an account (aka they have signed up in the past).</strong>
         <br/>
         <apex:pageBlockSection columns="1">
             <apex:pageBlockSectionItem >


### PR DESCRIPTION
We'll use the REINVITE email instead of the INTRO email for existing accounts because it's more intuitive and the language can be written to handle the case where you are signing up again for a non-LC opp or for a non-LC opp after signing up for an LC or Fellow role.  The INTRO email is for when you signup but don't complete your application.  It's a nudge to get you to submit.