### PR TITLE
Change Cultivation Level to exclude Email interactions 

### DIFF
--- a/src/classes/BZ_SetCultivationLevel.apxc
+++ b/src/classes/BZ_SetCultivationLevel.apxc
@@ -33,13 +33,14 @@ public class BZ_SetCultivationLevel {
                 
                 // When we send queued emails, the built in Salesforce email sending mechanism
                 // inserts a new completed task (and our code deletes the queued task that had
-                // the Interaction Type set).  This adjusts the interaction type for these.
+                // the Interaction Type set).  This adjusts the interaction type for these so the
+                // logic below picks it up.  Note: we should probably actually update the new
+                // Email task but we don't really need it for now and that is complicated
+                // b/c it would trigger calling this code again so we'll punt for now.
                 if (task.Subject.startsWith('Email:')){
                     task.Interaction_Type__c = 'Email';
                 }
-    
-                // All other Interaction_Type__c values other than Text correspond to those
-                // that we have met in some way.
+                
                 if (task.WhoId != null &&
                     !String.isEmpty(task.Interaction_Type__c) &&
                     task.Interaction_Type__c != '--None--')
@@ -47,7 +48,7 @@ public class BZ_SetCultivationLevel {
                     allContactIdsWeveInteractedWith.add(task.WhoId);
                     
                     //System.Debug('BZ_TaskClosed: adding Contact Id '+ task.WhoId + ' to contactIdsWeHaveMet');
-                    if (task.Interaction_Type__c == 'Email' || task.Interaction_Type__c == 'Voicemail' || 
+                    if (task.Interaction_Type__c == 'Voicemail' || 
                         task.Interaction_Type__c == 'Text Message'){
                         contactIdsWeHaveReachedOutTo.add(task.WhoId);
                     }
@@ -62,6 +63,11 @@ public class BZ_SetCultivationLevel {
                         // analogous to someone coming to our website and hearing about us 
                         // (e.g. a passing conversation at a larger function) but we haven't actively started 
                         // cultivating them yet.
+                        // 
+                        // Also, task.Interaction_Type__c == 'Email' is left blank since we email
+                        // people as part of the signup flow.  Ideally, we would distinguish between normal
+                        // signup flow related emails and explicit, manually created emails
+                        // but for now we'll just leave them blank.
                         otherContactIdsWeHaveInteractedWith.add(task.WhoId);
                     }
                 }
@@ -89,6 +95,7 @@ public class BZ_SetCultivationLevel {
             } else if (otherContactIdsWeHaveInteractedWith.contains(c.Id)){
                 c.Last_Interaction_Date__c = DateTime.now();
             }
+            System.debug('BZ_SetCultivationLevel: setting Contact[Last_Interaction_Date__c = ' + c.Last_Interaction_Date__c.getTime() + ', Cultivation_Level__c = ' + c.Cultivation_Level__c+']');
         }
         
         update contactIdToContactMap.values();
@@ -108,6 +115,7 @@ public class BZ_SetCultivationLevel {
                 Contact c = contactIdToContactMap.get(cm.ContactId);
                 cm.Last_Interaction_Date__c = c.Last_Interaction_Date__c;
                 cm.Cultivation_Level__c = c.Cultivation_Level__c;
+                System.debug('BZ_SetCultivationLevel: updating Campaign Member[Last_Interaction_Date__c = ' + cm.Last_Interaction_Date__c.getTime() + ', Cultivation_Level__c = ' + cm.Cultivation_Level__c+']');
             }
             update campaignMembersToUpdate;
         }

--- a/src/classes/BZ_TaskClosed_TEST.apxc
+++ b/src/classes/BZ_TaskClosed_TEST.apxc
@@ -18,6 +18,7 @@ private class BZ_TaskClosed_TEST {
         Task t1 = new Task(Subject='Test Interaction Task1', Status='Completed', OwnerId=sender.Id, WhoId=contact.Id);
         insert t1;
         
+        System.debug('BZ_TaskClosed_TEST: setting Interaction_Type__c = Attended BZ Function');
         t1.Interaction_Type__c = 'Attended BZ Function';
         update t1;
 
@@ -28,6 +29,21 @@ private class BZ_TaskClosed_TEST {
         System.assert(String.isEmpty(updatedCampaignMember.Cultivation_Level__c), 'Attended BZ Function interaction means we havent Reached Out or Met them.  Here is the value we found: ' + updatedCampaignMember.Cultivation_Level__c);
         System.assert(updatedCampaignMember.Last_Interaction_Date__c > DateTime.now().addMinutes(-20), 'The Last_Interaction_Date__c was not set to a recent time.  It is: '+updatedCampaignMember.Last_Interaction_Date__c+' which is less than '+DateTime.now().addMinutes(-20));
         
+        // Email shouldn't change the Cultivation Level since they happen as part of the
+        // normal signup flow.  We use Cultivation Level to tell if we need to reach out or talk
+        // to them directly to help them get through the application process.
+        System.debug('BZ_TaskClosed_TEST: setting Interaction_Type__c = Email');
+        t1.Interaction_Type__c = 'Email';
+        update t1;
+
+        updatedContact = [SELECT Id, Name, Cultivation_Level__c, Last_Interaction_Date__c FROM Contact WHERE Id = :contact.Id];
+        System.assert(String.isEmpty(updatedContact.Cultivation_Level__c), 'Email interaction means we havent Reached Out or Met them.  Here is the value we found: ' + updatedContact.Cultivation_Level__c);
+        System.assert(updatedContact.Last_Interaction_Date__c > DateTime.now().addMinutes(-20), 'The Last_Interaction_Date__c was not set to a recent time.  It is: '+updatedContact.Last_Interaction_Date__c+' which is less than '+DateTime.now().addMinutes(-20));
+        updatedCampaignMember = [SELECT Id, ContactId, Cultivation_Level__c, Last_Interaction_Date__c FROM CampaignMember WHERE ContactId = :contact.Id];
+        System.assert(String.isEmpty(updatedContact.Cultivation_Level__c), 'Email interaction means we havent Reached Out or Met them.  Here is the value we found: ' + updatedCampaignMember.Cultivation_Level__c);
+        System.assert(updatedCampaignMember.Last_Interaction_Date__c > DateTime.now().addMinutes(-20), 'The Last_Interaction_Date__c was not set to a recent time.  It is: '+updatedCampaignMember.Last_Interaction_Date__c+' which is less than '+DateTime.now().addMinutes(-20));
+        
+        System.debug('BZ_TaskClosed_TEST: setting Interaction_Type__c = Text Message');
         t1.Interaction_Type__c = 'Text Message';
         update t1;
 
@@ -37,7 +53,11 @@ private class BZ_TaskClosed_TEST {
         updatedCampaignMember = [SELECT Id, Cultivation_Level__c, Last_Interaction_Date__c FROM CampaignMember WHERE ContactId = :contact.Id];
         System.assert(updatedCampaignMember.Cultivation_Level__c == 'Reached Out', 'Text Message interaction means weve Reached Out, not: ' + updatedCampaignMember.Cultivation_Level__c);
         System.assert(updatedCampaignMember.Last_Interaction_Date__c > DateTime.now().addMinutes(-20), 'The Last_Interaction_Date__c was not set to a recent time.  It is: '+updatedCampaignMember.Last_Interaction_Date__c+' which is less than '+DateTime.now().addMinutes(-20));
+        // Note: i tried making sure the Last Interaction Date is greater than before 
+        // but working with datetimes down to the millisecond is a pain.  It was getting truncated
+        // somewhere even though I see it set properly in the logs.
 
+        System.debug('BZ_TaskClosed_TEST: setting Interaction_Type__c = 1:1 In-Person Meeting');
         t1.Interaction_Type__c = '1:1 In-Person Meeting';
         update t1;
 
@@ -50,6 +70,7 @@ private class BZ_TaskClosed_TEST {
         
         // We had a bug where if they were "Met" but then after went to a function,
         // the Cultivation Level was set back to null on the Campaign Member.  This tests that.
+        System.debug('BZ_TaskClosed_TEST: setting Interaction_Type__c = Interaction at Larger Function');
         t1.Interaction_Type__c = 'Interaction at Larger Function';
         update t1;
 


### PR DESCRIPTION
This field is so we can tell if we should reach out directly to help them finish the application process and since we email them as part of the process, we don't want to consider that as direct outreach.