### PR TITLE
Add support for queuing up emails for Mentor applicants. 

### DIFF
--- a/src/classes/BZ_BulkInviteController.apxc
+++ b/src/classes/BZ_BulkInviteController.apxc
@@ -318,7 +318,7 @@ public class BZ_BulkInviteController extends BZ_CsvBulkInviteUploader {
                     }
                     
                     CampaignMember cm;
-                    if (m_campaign.Type == 'Program Participants' || m_campaign.Type == 'Pre-Accelerator Participants'){
+                    if (m_campaign.Type == 'Program Participants' || m_campaign.Type == 'Pre-Accelerator Participants' || m_campaign.Type == 'Mentee'){
                         cm = new CampaignMember(ContactId=c.Id, campaignId=m_campaign.Id, Major__c=major, Undergrad_University__c=m_campaign.Program_Site__c, Bulk_Invite_Date__c=bulkInviteDateTime);
                     } else {
                         cm = new CampaignMember(ContactId=c.Id, campaignId=m_campaign.Id, Major__c=major, Bulk_Invite_Date__c=bulkInviteDateTime);

--- a/src/classes/BZ_CampaignAssigned_TEST.apxc
+++ b/src/classes/BZ_CampaignAssigned_TEST.apxc
@@ -258,7 +258,7 @@ private class BZ_CampaignAssigned_TEST {
                                      WHERE WhoId=:updatedCm.ContactId AND
                                            WhatId=:updatedCm.CampaignId AND
                                            Subject LIKE '%Send Intro Email%'];
-        System.assert(resultingTasks.size()==0, 'Expected NO Task to be created to Send Intro Email to Mentors');
+        System.assert(resultingTasks.size()==1, 'Expected 1 Task to be created to Send Intro Email to Mentors');
         
         Contact updatedContactConfirmed = [SELECT Id, Mentor_Information__c, Candidate_Status__c FROM Contact WHERE Id=:cmConfirmed.ContactId];
         System.assert(updatedContactConfirmed.Mentor_Information__c == 'Current', 'When a Confirmed Contact is Assigned to a Mentor campaign, their Mentor_Information__c should be set to Current.');
@@ -268,7 +268,7 @@ private class BZ_CampaignAssigned_TEST {
                                      WHERE WhoId=:updatedCmConfirmed.ContactId AND
                                            WhatId=:updatedCmConfirmed.CampaignId AND
                                            Subject LIKE '%Send Intro Email%'];
-        System.assert(resultingTasks.size()==0, 'Expected NO Task to be created to Send Intro Email to Mentors');
+        System.assert(resultingTasks.size()==1, 'Expected 1 Task to be created to Send Intro Email to Mentors');
         
         Contact updatedContactOptedOut = [SELECT Id, Mentor_Information__c, Candidate_Status__c FROM Contact WHERE Id=:cmOptedOut.ContactId];
         System.assert(updatedContactOptedOut.Mentor_Information__c == 'Opted Out', 'When a Opted Out Contact is Assigned to a Mentor campaign, their Mentor_Information__c should be set to Opted Out.');
@@ -278,7 +278,7 @@ private class BZ_CampaignAssigned_TEST {
                                      WHERE WhoId=:updatedCmOptedOut.ContactId AND
                                            WhatId=:updatedCmOptedOut.CampaignId AND
                                            Subject LIKE '%Send Intro Email%'];
-        System.assert(resultingTasks.size()==0, 'Expected NO Task to be created to Send Intro Email to Mentors');
+        System.assert(resultingTasks.size()==1, 'Expected 1 Task to be created to Send Intro Email to Mentors');
     }
     
     static testMethod void validateEventVolunteerCampaignAssigned() {

--- a/src/triggers/BZ_CampaignAssigned.apxt
+++ b/src/triggers/BZ_CampaignAssigned.apxt
@@ -149,7 +149,9 @@ trigger BZ_CampaignAssigned on CampaignMember (before insert) {
                 contact.Is_In_Active_Recruitment_Campaign__c = true;
             }
             isApplicableCampaign = true;
-            contactTypeThatGetsIntroEmail = false; // Invites and other emails happen through Mailchimp and Calendly.
+        //    
+        // TODO: do we want to handle Mentee's as well?
+        // 
         } else if (campaign.Type == 'Champion'){
             // Ditto on above comment.
             if (cm.Candidate_Status__c == 'Confirmed')

--- a/src/triggers/BZ_CampaignCompleted.apxt
+++ b/src/triggers/BZ_CampaignCompleted.apxt
@@ -58,6 +58,9 @@ trigger BZ_CampaignCompleted on Campaign (before update) {
                     c.Mentor_Information__c = 'Former';
                 }
             }
+            //
+            // TODO: do we want to handle Mentee information as well?
+            // 
             update contactsToUpdate;
             
             // Now that these people are Alumni, turn of their email notifications on Braven


### PR DESCRIPTION
New Mentor, Mentor that was something else, and someone who already signed up to be a mentor was tested using the Bulk Invite flow.