### PR TITLE
Add DocuSign and Qualtrics related fields for the Portal onboarding

### DIFF
--- a/docs/custom_fields.txt
+++ b/docs/custom_fields.txt
@@ -32,6 +32,9 @@
 		Interview Scheduler
 		Sourcing Info Options
     Volunteer Opportunities
+    Postaccelerator_Qualtrics_Survey_ID__c
+    Preaccelerator_Qualtrics_Survey_ID__c
+    Docusign_Template_ID__c
 
 	CAMPAIGN MEMBER
 		Candidate_Status_Confirmed__c


### PR DESCRIPTION
... and first time login flow.

If these fields are set on a campaign, then it causes people who login for the first time to have to sign DocuSign forms and it also allow us to embed Qualtrics surveys into the portal content.