### PR TITLE
Add TA Assignment information to the BZ_ProgramParticipantInfoService

### DIFF
--- a/src/classes/BZ_ProgramParticipantInfoService.apxc
+++ b/src/classes/BZ_ProgramParticipantInfoService.apxc
@@ -27,6 +27,7 @@ global without sharing class BZ_ProgramParticipantInfoService
         public String DiscordInviteCode;
         public String DiscordUserId;
         public String DiscordServerId;
+        public List<String> TeachingAssistantSections;
         public String ZoomPrefix;
         public String ZoomMeetingId1;
         public String ZoomMeetingId2;
@@ -68,7 +69,14 @@ global without sharing class BZ_ProgramParticipantInfoService
                        'Discord_Invite_Code__c, Contact__r.Discord_User_ID__c, Program__r.Discord_Server_ID__c, ' +
                        'Cohort__r.name, Cohort__r.Id, Cohort__r.Zoom_Prefix__c, Cohort_Schedule__r.Id, Cohort_Schedule__r.DayTime__c, ' +
                        'Cohort_Schedule__r.Webinar_Registration_1__c, Cohort_Schedule__r.Webinar_Registration_2__c, ' +
-                       'Webinar_Access_1__c, Webinar_Access_2__c ' +
+                       'Webinar_Access_1__c, Webinar_Access_2__c, ' +
+                       '(' +
+                         'SELECT TA_Participant__r.Contact__r.firstName, TA_Participant__r.Contact__r.lastName '+
+                         'FROM TA_Assignments__r'+
+                       '), ' +
+                       '(' +
+                         'SELECT Id FROM TA_Caseload__r LIMIT 1'+ // We only need to know if a TA has a Caseload. Note that count() doesnt work in dynamic SOQL.
+                       ') ' +
                        'FROM Participant__c ' +
                        'WHERE (Program__r.status__c=\'Current\' OR Program__r.status__c=\'Future\') AND ' +
                               'Program__r.recordtypeid IN :rts AND LastModifiedDate > :lastModifiedSince';
@@ -131,6 +139,22 @@ global without sharing class BZ_ProgramParticipantInfoService
             	if(thisContactsEduAffiliations.get(part.Program__r.school__c) !=null)
                     ps.StudentId=thisContactsEduAffiliations.get(part.Program__r.school__c);
             }
+
+            // Get the list of Canvas sections that this Participant should be added to in order
+            // to group them by their TA Assignment. For Fellows, this could be a list of TA names.
+            // For TA's, if they have Fellows assigned to them it will just be their own name.
+            // We do that for TA's so that we don't have to create Canvas sections for TA's that have
+            // no assignments.
+            List<String> taNamesForCanvasTaSections = new List<String>();
+            if (part.TA_Assignments__r.size() > 0) {
+                for(TA_Assignment__c tas:part.TA_Assignments__r){
+                    taNamesForCanvasTaSections.add(tas.TA_Participant__r.Contact__r.firstName + ' ' + tas.TA_Participant__r.Contact__r.lastName);
+                }
+            } else if (part.TA_Caseload__r.size() > 0) {
+                taNamesForCanvasTaSections.add(part.Contact__r.firstName + ' ' + part.Contact__r.lastName);
+            }
+            ps.TeachingAssistantSections = taNamesForCanvasTaSections;
+
             resultList.add(ps);
         }
 


### PR DESCRIPTION
We need to be able to create Canvas sections that group the TA Assignments so that TA's can filter on their own assignments in the Gradebook. This adds the list of the TA names they are assignment to if they are.

Task: https://app.asana.com/0/1201131148207877/1200184617753686

Changeset where it was deployed [here](https://bebraven.lightning.force.com/lightning/setup/InboundChangeSet/page?address=%2Fchangemgmt%2FinboundChangeSetDetailPage.apexp%3Fcid%3D0EP5c000000sYj3).